### PR TITLE
feat(rbac): unifica matriz de permissoes entre backend e frontend

### DIFF
--- a/backend/src/config/permissions.js
+++ b/backend/src/config/permissions.js
@@ -1,0 +1,171 @@
+/**
+ * permissions.js
+ *
+ * Fonte unica da matriz de RBAC do Obra Integrada.
+ * Usado por:
+ *   - Backend: middlewares de autorizacao (authorizationMiddleware.js)
+ *   - Frontend: copia espelhada em frontend/vite-project/src/utils/permissions.js
+ *
+ * Ao alterar este arquivo, atualizar a copia do frontend no MESMO PR.
+ * Quando o projeto migrar para workspaces, esta duplicacao sera extraida
+ * para um pacote compartilhado.
+ */
+
+// --- Catalogo de roles ----------------------------------------------------
+// USER e fallback para qualquer role desconhecida no banco.
+
+export const ROLES = Object.freeze({
+  ADMIN_MASTER: 'ADMIN_MASTER',
+  ADMIN:        'ADMIN',
+  PROPRIETARIO: 'PROPRIETARIO',
+  RESPONSAVEL:  'RESPONSAVEL',
+  TRABALHADOR:  'TRABALHADOR',
+  CLIENTE:      'CLIENTE',
+  USER:         'USER',
+});
+
+export const ROLES_PLATAFORMA = [ROLES.ADMIN_MASTER, ROLES.ADMIN];
+export const ROLES_OBRA = [ROLES.RESPONSAVEL, ROLES.TRABALHADOR];
+
+// --- Labels para exibicao -------------------------------------------------
+
+export const ROLE_LABELS = Object.freeze({
+  ADMIN_MASTER: 'Administrador da Plataforma',
+  ADMIN:        'Administrador',
+  PROPRIETARIO: 'Proprietario',
+  RESPONSAVEL:  'Responsavel Tecnico (Engenheiro)',
+  TRABALHADOR:  'Trabalhador',
+  CLIENTE:      'Cliente',
+  USER:         'Usuario',
+});
+
+// --- Matriz de permissoes -------------------------------------------------
+// true = tem permissao. Permissao ausente do objeto = false.
+
+export const PERMISSOES = Object.freeze({
+  ADMIN_MASTER: {
+    ver_metricas_plataforma: true,
+    gerenciar_clientes:      true,
+    impersonar:              true,
+    ver_obras:               true,
+    criar_obra:              true,
+    editar_obra:             true,
+    excluir_obra:            true,
+    ver_diario:              true,
+    criar_diario:            true,
+    auditar_diario:          true,
+    excluir_diario:          true,
+    deletar_diario:          true,
+    ver_tarefas:             true,
+    gerenciar_tarefas:       true,
+    atualizar_status_tarefa: true,
+    ver_financeiro:          true,
+    gerenciar_financeiro:    true,
+    ver_equipe:              true,
+    gerenciar_equipe:        true,
+    ver_rh:                  true,
+    gerenciar_usuarios:      true,
+    ver_perfil:              true,
+  },
+  ADMIN: {
+    ver_metricas_plataforma: true,
+    ver_obras:               true,
+    ver_diario:              true,
+    ver_tarefas:             true,
+    ver_financeiro:          true,
+    ver_equipe:              true,
+    ver_rh:                  true,
+    ver_perfil:              true,
+  },
+  PROPRIETARIO: {
+    ver_obras:               true,
+    criar_obra:              true,
+    editar_obra:             true,
+    excluir_obra:            true,
+    ver_diario:              true,
+    criar_diario:            true,
+    auditar_diario:          true,
+    excluir_diario:          true,
+    deletar_diario:          true,
+    ver_tarefas:             true,
+    gerenciar_tarefas:       true,
+    atualizar_status_tarefa: true,
+    ver_financeiro:          true,
+    gerenciar_financeiro:    true,
+    ver_equipe:              true,
+    gerenciar_equipe:        true,
+    ver_rh:                  true,
+    gerenciar_usuarios:      true,
+    ver_perfil:              true,
+  },
+  RESPONSAVEL: {
+    ver_obras:               true,
+    criar_obra:              true,
+    editar_obra:             true,
+    ver_diario:              true,
+    criar_diario:            true,
+    auditar_diario:          true,
+    excluir_diario:          true,
+    deletar_diario:          true,
+    ver_tarefas:             true,
+    gerenciar_tarefas:       true,
+    atualizar_status_tarefa: true,
+    ver_financeiro:          true,
+    gerenciar_financeiro:    true,
+    ver_equipe:              true,
+    gerenciar_equipe:        true,
+    ver_rh:                  true,
+    ver_perfil:              true,
+  },
+  TRABALHADOR: {
+    ver_obras:               true,
+    ver_diario:              true,
+    ver_tarefas:             true,
+    atualizar_status_tarefa: true,
+    ver_equipe:              true,
+    ver_perfil:              true,
+  },
+  CLIENTE: {
+    ver_obras:               true,
+    ver_diario:              true,
+    ver_tarefas:             true,
+    ver_financeiro:          true,
+    ver_equipe:              true,
+    ver_perfil:              true,
+    is_readonly:             true,
+  },
+  USER: {
+    ver_perfil:              true,
+  },
+});
+
+// --- Helpers --------------------------------------------------------------
+
+export function getPermissoes(role) {
+  return PERMISSOES[role] || PERMISSOES.USER;
+}
+
+export function hasPermissao(role, permissao) {
+  const perms = getPermissoes(role);
+  return !!perms[permissao];
+}
+
+export function hasRole(role, ...rolesPermitidos) {
+  return rolesPermitidos.includes(role);
+}
+
+export function getRoleLabel(role) {
+  return ROLE_LABELS[role] || role || 'Usuario';
+}
+
+export function isPlataforma(role) {
+  return ROLES_PLATAFORMA.includes(role);
+}
+
+export function isObra(role) {
+  return ROLES_OBRA.includes(role) || role === ROLES.PROPRIETARIO;
+}
+
+export function podeImpersonar(role) {
+  return hasPermissao(role, 'impersonar');
+}

--- a/backend/src/middlewares/authorizationMiddleware.js
+++ b/backend/src/middlewares/authorizationMiddleware.js
@@ -1,39 +1,23 @@
 /**
  * authorizationMiddleware.js
  *
- * Middlewares reutilizáveis de autorização baseados em RBAC.
+ * Middlewares reutilizaveis de autorizacao baseados em RBAC.
+ * A matriz de permissoes vive em ../config/permissions.js (fonte unica).
  *
  * Uso:
- *   router.get('/rota', authMiddleware, requireRole('ADMIN','MASTER'), controller)
+ *   router.get('/rota', authMiddleware, requireRole('ADMIN_MASTER'), controller)
  *   router.get('/obs/:id/diario', authMiddleware, requireObraAccess('leitura'), controller)
+ *   router.post('/diario', authMiddleware, requirePermissao('criar_diario'), controller)
  */
 
 import prisma from '../config/prisma.js';
+import { PERMISSOES, hasPermissao } from '../config/permissions.js';
 
-// ─── Mapa de permissões por role ──────────────────────────────────────────────
-const ROLES_PLATAFORMA = ['ADMIN_MASTER', 'MASTER', 'ADMIN', 'DEV', 'FIN', 'RH', 'SUPORTE'];
-const ROLES_OBRA       = ['PROPRIETARIO', 'RESPONSAVEL', 'CLIENTE', 'CONVIDADO_CLIENTE', 'TRABALHADOR'];
+// Re-export para nao quebrar imports antigos de PERMISSOES daqui
+export { PERMISSOES };
 
-export const PERMISSOES = {
-  ADMIN_MASTER: { plataforma: true,  obras: true,  criar_diario: true,  deletar_diario: true,  impersonar: true,  gerenciar_tarefas: true,  atualizar_status_tarefa: true, gerenciar_usuarios: true },
-  MASTER:       { plataforma: true,  obras: true,  criar_diario: true,  deletar_diario: true,  impersonar: true,  gerenciar_tarefas: true,  atualizar_status_tarefa: true, gerenciar_usuarios: true },
-  ADMIN:        { plataforma: true,  obras: true,  criar_diario: true,  deletar_diario: true,  impersonar: true,  gerenciar_tarefas: true,  atualizar_status_tarefa: true, gerenciar_usuarios: true },
-  DEV:          { plataforma: true,  obras: false, criar_diario: false, deletar_diario: true,  impersonar: true,  gerenciar_tarefas: true,  atualizar_status_tarefa: true, gerenciar_usuarios: false },
-  FIN:          { plataforma: true,  obras: false, criar_diario: false, deletar_diario: false, impersonar: false, gerenciar_tarefas: false, atualizar_status_tarefa: false, gerenciar_usuarios: false },
-  RH:           { plataforma: true,  obras: false, criar_diario: false, deletar_diario: false, impersonar: false, gerenciar_tarefas: false, atualizar_status_tarefa: false, gerenciar_usuarios: true },
-  SUPORTE:      { plataforma: true,  obras: false, criar_diario: false, deletar_diario: false, impersonar: false, gerenciar_tarefas: false, atualizar_status_tarefa: false, gerenciar_usuarios: false },
-  PROPRIETARIO: { plataforma: false, obras: true,  criar_diario: true,  deletar_diario: true,  impersonar: false, gerenciar_tarefas: true,  atualizar_status_tarefa: true, gerenciar_usuarios: true },
-  CLIENTE:      { plataforma: false, obras: true,  criar_diario: false, deletar_diario: false, impersonar: false, gerenciar_tarefas: false, atualizar_status_tarefa: false },
-  CONVIDADO_CLIENTE: { plataforma: false, obras: true,  criar_diario: false, deletar_diario: false, impersonar: false, gerenciar_tarefas: false, atualizar_status_tarefa: false },
-  RESPONSAVEL:  { plataforma: false, obras: true,  criar_diario: true,  deletar_diario: true,  impersonar: false, gerenciar_tarefas: true,  atualizar_status_tarefa: true, gerenciar_usuarios: true },
-  TRABALHADOR:  { plataforma: false, obras: true,  criar_diario: false, deletar_diario: false, impersonar: false, gerenciar_tarefas: false, atualizar_status_tarefa: true  },
-  USER:         { plataforma: false, obras: true,  criar_diario: false, deletar_diario: false, impersonar: false, gerenciar_tarefas: false, atualizar_status_tarefa: false },
-};
+// --- 1. requireRole -------------------------------------------------------
 
-// ─── 1. requireRole — verifica se o usuário tem o cargo necessário ────────────
-/**
- * @param {...string} roles - Roles permitidas (ex: 'ADMIN', 'MASTER', 'DEV')
- */
 export function requireRole(...roles) {
   return (req, res, next) => {
     const userRole = req.user?.role;
@@ -53,23 +37,20 @@ export function requireRole(...roles) {
   };
 }
 
-// ─── 2. requirePermissao — verifica uma permissao especifica do RBAC ──────────
-/**
- * @param {string} permissao - Permissao do mapa PERMISSOES (ex: 'criar_diario')
- */
+// --- 2. requirePermissao --------------------------------------------------
+
 export function requirePermissao(permissao) {
   return (req, res, next) => {
     const role = req.user?.role;
-    const perms = PERMISSOES[role];
 
-    if (!perms) {
-      return res.status(403).json({ erro: 'Cargo nao reconhecido' });
+    if (!role) {
+      return res.status(401).json({ erro: 'Nao autenticado' });
     }
 
-    if (!perms[permissao]) {
+    if (!hasPermissao(role, permissao)) {
       _logAcessoNegado(req, `Permissao '${permissao}' negada para role '${role}'`);
       return res.status(403).json({
-        erro: `Acao nao permitida para seu nivel de acesso.`,
+        erro: 'Acao nao permitida para seu nivel de acesso.',
       });
     }
 
@@ -77,18 +58,12 @@ export function requirePermissao(permissao) {
   };
 }
 
-// ─── 3. requireObraAccess — verifica vinculo do usuario com a obra ─────────────
-/**
- * Verifica se o usuário está vinculado à obra (:id na rota).
- * Popula req.obraAccess com { idObra, role, nivelAcesso }.
- *
- * Niveis de acesso:
- *   total    → RESPONSAVEL, MASTER, ADMIN, DEV
- *   leitura  → CLIENTE, todos os de plataforma com permissao
- *   nenhum   → qualquer outro
- *
- * @param {'total'|'leitura'|'qualquer'} nivelMinimo
- */
+// --- 3. requireObraAccess -------------------------------------------------
+// Verifica se o usuario esta vinculado a obra (:id na rota).
+// Popula req.obraAccess com { idObra, role, nivelAcesso }.
+//
+// Niveis: total, leitura, qualquer
+
 export function requireObraAccess(nivelMinimo = 'qualquer') {
   return async (req, res, next) => {
     try {
@@ -100,53 +75,37 @@ export function requireObraAccess(nivelMinimo = 'qualquer') {
         return res.status(400).json({ erro: 'ID da obra invalido' });
       }
 
-      // Usuarios de plataforma com permissao total (MASTER/ADMIN/DEV) ignoram vinculo
-      if (['ADMIN_MASTER', 'MASTER', 'ADMIN', 'DEV'].includes(role)) {
+      // Roles de plataforma com permissao total ignoram vinculo
+      if (['ADMIN_MASTER', 'ADMIN'].includes(role)) {
         req.obraAccess = { idObra, role, nivelAcesso: 'total' };
         return next();
       }
 
-      // NOVO: Usuarios PROPRIETARIO dependem do vínculo id_cliente (Multi-tenancy)
+      // PROPRIETARIO acessa obras da propria empresa via id_cliente
       if (role === 'PROPRIETARIO') {
         const idClienteUsuario = req.user?.id_cliente;
         if (!idClienteUsuario) {
           return res.status(403).json({ erro: 'Proprietario sem empresa vinculada' });
         }
 
-        // Verifica se esta obra pertence à empresa deste proprietário
         const obraDaEmpresa = await prisma.tb_obra_cliente.findFirst({
-          where: {
-            id_obra: idObra,
-            id_cliente: idClienteUsuario,
-          }
+          where: { id_obra: idObra, id_cliente: idClienteUsuario }
         });
 
         if (obraDaEmpresa) {
           req.obraAccess = { idObra, role, nivelAcesso: 'total' };
           return next();
         }
-
-        // Se o proprietário não for o dono direto, talvez ele esteja vinculado como usuário comum? 
-        // (Raro, mas compatível com o fluxo abaixo)
       }
 
-      // Para usuarios de obra: verifica vinculo em tb_usuario_obra
+      // Demais usuarios: verifica vinculo em tb_usuario_obra
       const vinculo = await prisma.tb_usuario_obra.findFirst({
-        where: {
-          id_usuario: idUsuario,
-          id_obra: idObra,
-        },
-        include: {
-          tb_papel: true,
-        },
+        where: { id_usuario: idUsuario, id_obra: idObra },
+        include: { tb_papel: true },
       });
 
-      // Verifica tambem se seria RESPONSAVEL direto pela obra
       const obraResponsavel = await prisma.tb_obra.findFirst({
-        where: {
-          id_obra: idObra,
-          id_usuario_responsavel: idUsuario,
-        },
+        where: { id_obra: idObra, id_usuario_responsavel: idUsuario },
       });
 
       const temAcesso = vinculo || obraResponsavel;
@@ -158,13 +117,11 @@ export function requireObraAccess(nivelMinimo = 'qualquer') {
         });
       }
 
-      // Determina nivel de acesso real
       let nivelAcesso = 'leitura';
       if (role === 'RESPONSAVEL' || role === 'PROPRIETARIO' || obraResponsavel) {
         nivelAcesso = 'total';
       }
 
-      // Verifica se atende ao nivel minimo exigido
       const hierarquia = { 'qualquer': 0, 'leitura': 1, 'total': 2 };
       if (hierarquia[nivelAcesso] < hierarquia[nivelMinimo]) {
         _logAcessoNegado(req, `Nivel ${nivelAcesso} insuficiente (necessario: ${nivelMinimo}) para obra ${idObra}`);
@@ -173,7 +130,6 @@ export function requireObraAccess(nivelMinimo = 'qualquer') {
         });
       }
 
-      // Disponibiliza info de acesso para os controllers
       req.obraAccess = { idObra, role, nivelAcesso, vinculo };
       next();
 
@@ -184,7 +140,8 @@ export function requireObraAccess(nivelMinimo = 'qualquer') {
   };
 }
 
-// ─── Helper privado: log de acesso negado ─────────────────────────────────────
+// --- Helper: log de acesso negado -----------------------------------------
+
 function _logAcessoNegado(req, motivo) {
   const userId = req.user?.id || 'anonimo';
   const role   = req.user?.role || 'sem-role';
@@ -192,6 +149,4 @@ function _logAcessoNegado(req, motivo) {
   const ip     = req.headers['x-forwarded-for'] || req.socket?.remoteAddress || 'desconhecido';
 
   console.warn(`[ACESSO NEGADO] Usuario=${userId} Role=${role} IP=${ip} Rota="${rota}" | ${motivo}`);
-
-  // Futuramente: salvar em tb_log_auditoria via prisma
 }

--- a/frontend/vite-project/src/utils/permissions.js
+++ b/frontend/vite-project/src/utils/permissions.js
@@ -1,243 +1,150 @@
 /**
  * permissions.js
  *
- * Espelho do RBAC do backend — define o que cada role pode fazer no frontend.
- * O backend SEMPRE valida as permissoes reais.
- * Este arquivo controla a visibilidade de componentes na UI.
+ * COPIA ESPELHADA DE: backend/src/config/permissions.js
+ *
+ * O backend e a fonte unica da verdade. Ao alterar a matriz, atualize
+ * OS DOIS arquivos no mesmo PR. Quando o projeto migrar para workspaces,
+ * essa duplicacao sera extraida para um pacote compartilhado.
+ *
+ * O backend SEMPRE valida as permissoes reais em cada request.
+ * Este arquivo apenas controla a visibilidade de componentes na UI.
  */
 
-// ─── Grupo de roles (Sincronizado com backend/src/seedTestes.js) ────────────
-export const ROLES_PLATAFORMA = [
-  'ADMIN_MASTER', 
-  'ADMIN_DEV', 
-  'ADMIN_FIN', 
-  'ADMIN_RH', 
-  'ADMIN'
-];
+// --- Catalogo de roles ----------------------------------------------------
 
-export const ROLES_OBRA = [
-  'PROPRIETARIO',
-  'RESPONSAVEL', 
-  'CLIENTE', 
-  'TRABALHADOR'
-];
+export const ROLES = Object.freeze({
+  ADMIN_MASTER: 'ADMIN_MASTER',
+  ADMIN:        'ADMIN',
+  PROPRIETARIO: 'PROPRIETARIO',
+  RESPONSAVEL:  'RESPONSAVEL',
+  TRABALHADOR:  'TRABALHADOR',
+  CLIENTE:      'CLIENTE',
+  USER:         'USER',
+});
 
-// Mapeamento de roles (Backend Keys -> Frontend Labels)
-export const ROLE_LABELS = {
-  ADMIN_MASTER:      'Administrador Master',
-  ADMIN_DEV:         'Desenvolvedor',
-  ADMIN_FIN:         'Gestor Financeiro',
-  ADMIN_RH:          'Gestor de Pessoas',
-  ADMIN:             'Administrador',
-  PROPRIETARIO:      'Proprietário',
-  RESPONSAVEL:       'Responsável Técnico (Engenheiro)',
-  CLIENTE:           'Cliente (Dono)',
-  CONVIDADO_CLIENTE: 'Espectador (Convidado)',
-  TRABALHADOR:       'Trabalhador',
-  MESTRE:            'Mestre de Obras',
-  PEDREIRO:          'Pedreiro',
-  AJUDANTE:          'Ajudante',
-  USER:              'Usuário',
-};
+export const ROLES_PLATAFORMA = [ROLES.ADMIN_MASTER, ROLES.ADMIN];
+export const ROLES_OBRA = [ROLES.RESPONSAVEL, ROLES.TRABALHADOR];
 
-// ─── Mapa de permissoes por role ──────────────────────────────────────────────
-export const PERMISSOES = {
+// --- Labels ---------------------------------------------------------------
+
+export const ROLE_LABELS = Object.freeze({
+  ADMIN_MASTER: 'Administrador da Plataforma',
+  ADMIN:        'Administrador',
+  PROPRIETARIO: 'Proprietario',
+  RESPONSAVEL:  'Responsavel Tecnico (Engenheiro)',
+  TRABALHADOR:  'Trabalhador',
+  CLIENTE:      'Cliente',
+  USER:         'Usuario',
+});
+
+// --- Matriz ---------------------------------------------------------------
+
+export const PERMISSOES = Object.freeze({
   ADMIN_MASTER: {
     ver_metricas_plataforma: true,
-    ver_metricas_globais:    true,
-    ver_clientes:            true,
-    gerenciar_usuarios:      true,
+    gerenciar_clientes:      true,
     impersonar:              true,
-    ver_logs:                true,
-    ver_obras:               true, // Global
+    ver_obras:               true,
     criar_obra:              true,
+    editar_obra:             true,
+    excluir_obra:            true,
     ver_diario:              true,
+    criar_diario:            true,
+    auditar_diario:          true,
+    excluir_diario:          true,
+    deletar_diario:          true,
     ver_tarefas:             true,
     gerenciar_tarefas:       true,
     atualizar_status_tarefa: true,
-    ver_financeiro_global:   true,
-    ver_financeiro_obra:     true,
-    ver_materiais_obra:      true,
-    ver_equipe_obra:         true,
+    ver_financeiro:          true,
+    gerenciar_financeiro:    true,
+    ver_equipe:              true,
+    gerenciar_equipe:        true,
+    ver_rh:                  true,
+    gerenciar_usuarios:      true,
     ver_perfil:              true,
-    configuracoes_sistema:   true,
   },
-  // Nível 1 - Administrador da Plataforma
   ADMIN: {
     ver_metricas_plataforma: true,
-    ver_metricas_globais:    true,
-    ver_clientes:            true,
-    gerenciar_usuarios:      true,
-    impersonar:              true,
-    ver_logs:                true,
-    ver_obras:               true,
-    criar_obra:              true,
-    ver_diario:              true,
-    ver_tarefas:             true,
-    gerenciar_tarefas:       true,
-    atualizar_status_tarefa: true,
-    ver_financeiro_global:   true,
-    ver_financeiro_obra:     true,
-    ver_materiais_obra:      true,
-    ver_equipe_obra:         true,
-    ver_perfil:              true,
-    configuracoes_sistema:   true,
-  },
-  ADMIN_DEV: {
-    ver_metricas_plataforma: true,
     ver_obras:               true,
     ver_diario:              true,
     ver_tarefas:             true,
-    gerenciar_tarefas:       true,
-    atualizar_status_tarefa: true,
-    ver_perfil:              true,
-    ver_logs:                true,
-    configuracoes_sistema:   true,
-  },
-  ADMIN_FIN: {
-    ver_metricas_plataforma: true,
-    ver_obras:               true,
-    ver_financeiro_global:   true,
-    ver_financeiro_obra:     true,
+    ver_financeiro:          true,
+    ver_equipe:              true,
+    ver_rh:                  true,
     ver_perfil:              true,
   },
-  ADMIN_RH: {
-    ver_metricas_plataforma: true,
-    ver_obras:               true,
-    ver_equipe_obra:         true,
-    gerenciar_usuarios:      true,
-    ver_perfil:              true,
-  },
-  // Nível 2 - Dono da Construtora
   PROPRIETARIO: {
     ver_obras:               true,
     criar_obra:              true,
-    criar_diario:            true,
+    editar_obra:             true,
+    excluir_obra:            true,
     ver_diario:              true,
-    ver_financeiro:          true,
-    gerenciar_equipe:        true,
-    gerenciar_usuarios:      true,
+    criar_diario:            true,
+    auditar_diario:          true,
+    excluir_diario:          true,
+    deletar_diario:          true,
     ver_tarefas:             true,
     gerenciar_tarefas:       true,
     atualizar_status_tarefa: true,
-    escrever_diario:         true,
-    deletar_diario:          true,
-    auditar_diario:          true, 
-    ver_materiais_obra:      true,
-    ver_financeiro_obra:     true,
-    ver_equipe_obra:         true,
+    ver_financeiro:          true,
+    gerenciar_financeiro:    true,
+    ver_equipe:              true,
+    gerenciar_equipe:        true,
+    ver_rh:                  true,
+    gerenciar_usuarios:      true,
     ver_perfil:              true,
-    ver_metricas_empresa:    true,
   },
-  // Nível 2 - Operacional
   RESPONSAVEL: {
     ver_obras:               true,
     criar_obra:              true,
-    criar_diario:            true,
+    editar_obra:             true,
     ver_diario:              true,
-    ver_financeiro:          true,
-    gerenciar_equipe:        true,
-    gerenciar_usuarios:      true,
+    criar_diario:            true,
+    auditar_diario:          true,
+    excluir_diario:          true,
+    deletar_diario:          true,
     ver_tarefas:             true,
     gerenciar_tarefas:       true,
     atualizar_status_tarefa: true,
-    escrever_diario:         true,
-    deletar_diario:          true,
-    auditar_diario:          true, 
-    ver_materiais_obra:      true,
-    ver_financeiro_obra:     true,
-    ver_equipe_obra:         true,
+    ver_financeiro:          true,
+    gerenciar_financeiro:    true,
+    ver_equipe:              true,
+    gerenciar_equipe:        true,
+    ver_rh:                  true,
+    ver_perfil:              true,
+  },
+  TRABALHADOR: {
+    ver_obras:               true,
+    ver_diario:              true,
+    ver_tarefas:             true,
+    atualizar_status_tarefa: true,
+    ver_equipe:              true,
     ver_perfil:              true,
   },
   CLIENTE: {
     ver_obras:               true,
     ver_diario:              true,
-    ver_financeiro_obra:     true, // Leitura
-    ver_materiais_obra:      true, // Leitura
-    ver_equipe_obra:         true, // Leitura
     ver_tarefas:             true,
-    convidar_espectador:     true, // Exclusivo
-    is_readonly:             true, // Global ReadOnly
-  },
-  CONVIDADO_CLIENTE: {
-    ver_obras:               true,
-    ver_diario:              true,
-    ver_financeiro_obra:     true,
-    ver_materiais_obra:      true,
-    ver_equipe_obra:         true,
-    ver_tarefas:             true,
+    ver_financeiro:          true,
+    ver_equipe:              true,
+    ver_perfil:              true,
     is_readonly:             true,
   },
-  MESTRE: {
-    ver_obras:               true,
-    ver_diario:              true,
-    ver_equipe:              true,
-    ver_tarefas:             true,
-    gerenciar_tarefas:       true,
-    atualizar_status_tarefa: true,
-    escrever_diario:         true,
-    delegar_tarefa:          true,
-  },
-  PEDREIRO: {
-    ver_obras:               true,
-    ver_tarefas_proprias:    true,
-    atualizar_progresso:     true,
-    atualizar_status_tarefa: true,
-    ver_perfil:              true,
-  },
-  AJUDANTE: {
-    ver_tarefas_hoje:        true,
-    atualizar_status_tarefa: true,
-    ver_perfil:              true,
-  },
-  TRABALHADOR: {
-    ver_obras:               true,
-    ver_tarefas:             true,
-    atualizar_status_tarefa: true,
-    ver_diario:              true,
-    ver_perfil:              true,
-  },
   USER: {
-    ver_obras:               true,
     ver_perfil:              true,
   },
-};
+});
 
-// ─── Funcoes helper ───────────────────────────────────────────────────────────
+// --- Helpers --------------------------------------------------------------
 
-/**
- * Retorna o "Perfil Estrutural" simplificado para controle de UI.
- */
-export function getProfile(role, funcao) {
-  if (role === 'ADMIN_MASTER') return 'ADMIN_MASTER';
-  if (role === 'ADMIN')        return 'ADMIN';
-  if (role === 'ADMIN_DEV')    return 'ADMIN_DEV';
-  if (role === 'ADMIN_FIN')    return 'ADMIN_FIN';
-  if (role === 'ADMIN_RH')     return 'ADMIN_RH';
-  if (role === 'PROPRIETARIO') return 'PROPRIETARIO';
-  if (role === 'CLIENTE')      return 'CLIENTE';
-  if (role === 'CONVIDADO_CLIENTE') return 'CONVIDADO_CLIENTE';
-  if (role === 'RESPONSAVEL')  return 'RESPONSAVEL';
-  if (role === 'TRABALHADOR')  return 'TRABALHADOR';
-  
-  if (role === 'USER') {
-    const f = funcao?.toUpperCase();
-    if (f === 'MESTRE') return 'MESTRE';
-    if (f === 'PEDREIRO') return 'PEDREIRO';
-    if (f === 'AJUDANTE') return 'AJUDANTE';
-  }
-  
-  return role || 'USER';
+export function getPermissoes(role) {
+  return PERMISSOES[role] || PERMISSOES.USER;
 }
 
-export function getPermissoes(role, funcao) {
-  const profile = getProfile(role, funcao);
-  return PERMISSOES[profile] || PERMISSOES['USER'];
-}
-
-
-export function hasPermissao(role, permissao, funcao) {
-  const perms = getPermissoes(role, funcao);
+export function hasPermissao(role, permissao) {
+  const perms = getPermissoes(role);
   return !!perms[permissao];
 }
 
@@ -245,21 +152,8 @@ export function hasRole(role, ...rolesPermitidos) {
   return rolesPermitidos.includes(role);
 }
 
-export function getRoleLabel(role, funcao) {
-  // 1. Prioridade para Nível 1 (Plataforma)
-  if (role === 'ADMIN_MASTER') return 'Administrador da Plataforma';
-  if (role === 'PROPRIETARIO') return 'Proprietário';
-  if (role === 'CLIENTE') return 'Cliente (Dono da Obra)';
-  if (role === 'CONVIDADO_CLIENTE') return 'Espectador (Convidado)';
-
-  // 2. Nível 2 (Operacional) - Se for trabalhador e tiver função, exibe função
-  if (role === 'TRABALHADOR' && funcao) {
-    const operTitle = funcao.toUpperCase();
-    return ROLE_LABELS[operTitle] || funcao;
-  }
-
-  // 3. Fallback para o label mapeado ou a própria role
-  return ROLE_LABELS[role] || role || 'Usuário';
+export function getRoleLabel(role) {
+  return ROLE_LABELS[role] || role || 'Usuario';
 }
 
 export function isPlataforma(role) {
@@ -267,9 +161,17 @@ export function isPlataforma(role) {
 }
 
 export function isObra(role) {
-  return ROLES_OBRA.includes(role) || role === 'TRABALHADOR';
+  return ROLES_OBRA.includes(role) || role === ROLES.PROPRIETARIO;
 }
 
 export function podeImpersonar(role) {
   return hasPermissao(role, 'impersonar');
+}
+
+// --- Compat: getProfile (usado em AppSidebar.tsx) -------------------------
+// No PR #2 essa funcao ganhara logica baseada em "funcao" (Mestre, Estagiario).
+// Por enquanto retorna a role direto.
+
+export function getProfile(role /*, funcao */) {
+  return role || ROLES.USER;
 }


### PR DESCRIPTION
## O que foi feito

- Cria backend/src/config/permissions.js como fonte unica da matriz RBAC
- Refatora authorizationMiddleware.js para importar do novo arquivo
- Refatora frontend/utils/permissions.js como espelho do backend
- Remove roles legadas nao utilizadas (MASTER, DEV, FIN, RH, SUPORTE, ADMIN_DEV, ADMIN_FIN, ADMIN_RH, CONVIDADO_CLIENTE)
- Mantem 7 roles ativas: ADMIN_MASTER, ADMIN, PROPRIETARIO, RESPONSAVEL, TRABALHADOR, CLIENTE, USER

## Por que

A matriz estava duplicada e dessincronizada entre backend e frontend (problema identificado na auditoria 01-auditoria-tecnica.md). Esta PR estabelece a fonte unica antes de adicionar novos perfis e proteger novas rotas.

## Como testar

1. Subir backend e frontend
2. Logar com qualquer usuario e verificar que o dashboard carrega
3. Logar como TRABALHADOR e confirmar que NAO ve o menu RH

## Proximas PRs

- feature/rbac-add-estagiario
- feature/rbac-backend-rotas
- feature/rbac-frontend-guards
- docs/rbac-matriz