### PR TITLE
fix(scripts): db:push e db:seed carregam backend/.env corretamente

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "frontend": "npm run dev --prefix frontend/vite-project",
     "backend": "npm run start --prefix backend",
     "install:all": "npm install && npm install --prefix backend && npm install --prefix frontend/vite-project",
-    "db:push": "npx prisma db push --schema=backend/src/prisma/schema.prisma"
+    "db:push": "cd backend && npx prisma db push",
+    "db:seed": "cd backend && npm run seed"
   },
   "type": "module",
   "keywords": [],


### PR DESCRIPTION
## O que foi feito

- Altera script `db:push` para entrar em `backend/` antes de rodar prisma (assim o .env eh carregado)
- Adiciona script `db:seed` na raiz por simetria

## Por que

O script anterior `npx prisma db push --schema=backend/src/prisma/schema.prisma` rodava da raiz, onde nao existe `.env`. Resultado: `Environment variable not found: DATABASE_URL`.

Com `cd backend && ...`, o Prisma e executado dentro da pasta onde o `.env` esta e funciona normalmente.

## Como testar

1. Confirmar que `backend/.env` tem `DATABASE_URL`
2. Da raiz: `npm run db:push` → deve sincronizar sem erro
3. Da raiz: `npm run db:seed` → deve popular o banco

## Notas

- O README ja documentava `npm run db:push` da raiz como caminho oficial — esse fix faz a documentacao virar realidade
- Isso destrava o passo 5 do "Como rodar localmente" do README pra novos colaboradores