### PR TITLE
docs(auditoria): adiciona artefatos da auditoria inicial

### DIFF
--- a/docs/docs/auditoria-inicial/01-auditoria-tecnica.md
+++ b/docs/docs/auditoria-inicial/01-auditoria-tecnica.md
@@ -1,0 +1,706 @@
+# Fase 1 — Auditoria Técnica Completa
+
+**Projeto:** Obra Integrada
+**Data:** 24 de abril de 2026
+**Escopo:** Monorepo fullstack (backend Express/Prisma + frontend React/Vite)
+**Responsável pela auditoria:** Arquitetura de software (consultoria externa)
+**Duração do desenvolvimento até aqui:** ~24 meses acumulados (projeto acadêmico)
+
+---
+
+## Sumário executivo
+
+A plataforma Obra Integrada está **operacional em ambiente local** e já implementa fluxos críticos (autenticação, cadastro de obras, diário de obra com GPS, tarefas, financeiro, RH e admin). A base arquitetural — Express 5 + Prisma 5 + PostgreSQL no backend, React 19 + Vite 7 + Tailwind 4 no frontend — é moderna e adequada para deploy serverless na Vercel.
+
+Contudo, a auditoria identificou **6 problemas críticos de segurança**, **duplicação estrutural (pastas `view/` legada convivendo com `pages/` moderna)**, **ausência de testes de integração reais** (os existentes são mocks), **acoplamento direto a Prisma nos controllers** e **bloqueadores concretos para produção na Vercel** (uso de `multer.diskStorage`, CORS permissivo total, JWT secret com fallback hardcoded). O débito técnico é significativo mas **gerenciável em horizonte de 6 meses** se tratado de forma incremental, como detalhado no artefato 03 desta auditoria.
+
+Não existem problemas bloqueadores para o prosseguimento do roadmap de 24 meses — há, sim, **5 ações de higiene imediata** (Semana 1) que devem preceder qualquer nova funcionalidade: remover `dev.db` do Git, apagar `server.js` da raiz, criar `.env.example`, criar `.vercelignore`, e corrigir o fallback do `JWT_SECRET`.
+
+---
+
+## 1.1. Inventário estrutural
+
+### 1.1.1. Visão geral do monorepo
+
+```
+obra-integrada/
+├── .gitignore                      # raiz (ignora node_modules, .env, /generated/prisma)
+├── LICENSE.md                      # MIT (aparentemente herdado do template TailAdmin)
+├── README.md                       # desatualizado (menciona "JSON mock, futuro MySQL")
+├── banner.png                      # 1.4 MB commitado — sem referência no README
+├── package.json                    # raiz — orquestrador (concurrently), mas com deps duplicadas
+├── package-lock.json               # 64 KB
+├── server.js                       # ARQUIVO OBSOLETO — duplica backend/src/server.js
+├── backend/                        # API Node.js
+├── frontend/vite-project/          # SPA React
+└── documentacao_banca/             # 1 arquivo RELATORIO_TECNICO.md (32 linhas, superficial)
+```
+
+**Observações imediatas:**
+
+| Item | Status | Comentário |
+|---|---|---|
+| `server.js` na raiz | ❌ Órfão | Versão antiga com apenas 2 rotas; não é importado em lugar nenhum |
+| `banner.png` | ⚠️ 1.4 MB no Git | Deveria estar em CDN ou referenciado por URL externa |
+| `package.json` raiz | ⚠️ Deps duplicadas | `@prisma/client`, `prisma`, `bcryptjs`, `cors`, `express`, `jsonwebtoken` estão em ambos `package.json` raiz e `backend/package.json` |
+| `documentacao_banca/` | ⚠️ Superficial | RELATORIO_TECNICO.md com 32 linhas; não substitui documentação técnica real |
+
+### 1.1.2. Estrutura do backend
+
+```
+backend/
+├── .gitignore
+├── check_db.mjs                    # ÓRFÃO — debug manual de conexão
+├── coverage/tmp/                   # arquivos .json de c8 COMMITADOS (erro)
+├── package.json
+├── package-lock.json
+├── seed_bulk.mjs                   # ÓRFÃO — versão antiga de seed
+├── seed_enrich.mjs                 # ÓRFÃO — versão antiga de seed
+├── seed_obras_detalhadas.mjs       # ÓRFÃO
+├── seed_out.txt                    # ÓRFÃO — log de saída de seed
+├── seed_tarefas_paginacao.mjs      # ÓRFÃO
+├── seed_vanguarda_rico.mjs         # ÓRFÃO
+├── standalone_users_server.js      # ÓRFÃO — servidor alternativo de 125 linhas não usado
+├── strip_maps.js                   # ÓRFÃO — script de limpeza de schema
+├── tests/
+│   ├── api.test.js                 # 40 linhas — testes MOCK (não de integração)
+│   └── rh.test.js                  # 65 linhas — testes MOCK
+├── uploads/                        # pasta com .gitignore correto (*, !.gitignore, !.gitkeep)
+├── vercel.json
+└── src/
+    ├── config/
+    │   ├── prisma.js               # singleton simples
+    │   └── storageService.js       # abstração de storage (preparada p/ S3 futuro)
+    ├── controllers/                # 10 arquivos (ver 1.1.3)
+    ├── database/
+    │   ├── obras.json              # MOCK LEGADO (42 linhas)
+    │   └── users.json              # MOCK LEGADO (110 linhas, com senhas hasheadas)
+    ├── middlewares/
+    │   ├── authMiddleware.js       # 34 linhas
+    │   ├── authorizationMiddleware.js  # 198 linhas — matriz RBAC
+    │   └── uploadMiddleware.js     # 113 linhas — multer diskStorage
+    ├── models/
+    │   ├── obra.js                 # 89 linhas — wrapper fino de Prisma
+    │   └── user.js                 # 37 linhas — wrapper fino de Prisma
+    ├── prisma/
+    │   ├── dev.db                  # ❌ SQLite COMMITADO (114 KB) — obsoleto, usa Postgres
+    │   ├── schema.prisma           # 326 linhas, 21 models
+    │   ├── schema.prisma.postgres  # ❌ DUPLICADO/DESATUALIZADO (192 linhas, 14 models)
+    │   ├── seed.js                 # oficial
+    │   └── migrations/
+    │       └── 20260415002034_advanced_features/migration.sql  # ÚNICA migration
+    ├── routes/                     # 7 arquivos (ver 1.1.3)
+    ├── utils/
+    │   └── validation.js           # 49 linhas — validarCPF, validarEmail
+    ├── seed.js                     # possível órfão
+    ├── prisma.config.ts            # config do CLI do Prisma
+    └── server.js                   # entry point atual
+```
+
+### 1.1.3. Mapeamento por módulo
+
+A tabela a seguir conecta cada módulo de negócio aos seus controllers, rotas, middlewares, models e ao frontend correspondente. Serve como referência única para a equipe localizar qualquer funcionalidade.
+
+#### Módulo **Obras**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/obraController.js` | 602 | Crítico — maior controller do projeto |
+| Rota | `backend/src/routes/obraRoutes.js` | 58 | Usa `requireObraAccess` |
+| Model | `backend/src/models/obra.js` | 89 | Wrapper de Prisma |
+| Middleware | `authMiddleware`, `authorizationMiddleware` | — | — |
+| Página FE (moderna) | `frontend/vite-project/src/pages/Obra/ObraPage.jsx` | 161 | Tabs simples |
+| Página FE (listagem) | `frontend/vite-project/src/pages/Obras/MinhasObrasPage.jsx` | — | Proteção via `PermissaoGuard(ver_obras)` |
+| Wizard | `frontend/vite-project/src/components/Dashboard/NovaObraWizard.jsx` | — | — |
+| Rotas protegidas | `/obras`, `/obra/:id` | — | — |
+
+**Funcionalidades cobertas:** CRUD de obras, equipe da obra (adicionar/remover/atualizar membros), estoque por obra (CRUD + histórico de movimentações), documentos da obra (upload), org-chart, filtragem RBAC de dados financeiros em `getObraById`.
+
+#### Módulo **Diário**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/diarioController.js` | 309 | Bom padrão: helper `registrarLog()` de auditoria |
+| Rota | `backend/src/routes/diarioRoutes.js` | 79 | Pipeline exemplar: auth → requireObraAccess → requirePermissao → upload |
+| Middleware | `uploadMiddleware` (subpasta `diario/`) | — | — |
+| Página FE | `frontend/vite-project/src/pages/Obra/sections/ObraDiario.jsx` | — | Acessada via tabs de `ObraPage` |
+
+**Funcionalidades cobertas:** listagem paginada, criação com foto + GPS + `status_auditoria`, exclusão com log de auditoria, edição de descrição, PATCH para auditoria (AUTORIZADO/REPROVADO).
+
+#### Módulo **Tarefas**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/tarefaController.js` | 233 | Operações sem `$transaction` — risco de inconsistência em re-sync de usuários |
+| Rota | `backend/src/routes/tarefaRoutes.js` | 59 | Duplicação: `GET /tarefas` (global) e `GET /obras/:id/tarefas` |
+| Página FE | `frontend/vite-project/src/pages/Calendar.tsx` | — | Usa FullCalendar (pesado — ~200 KB) |
+
+**Funcionalidades cobertas:** CRUD de tarefas, atualização de status, atribuição a múltiplos usuários via `tb_tarefa_usuario`, percentual de conclusão.
+
+#### Módulo **Financeiro**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/financeiroController.js` | 146 | Função `getOrgChart` DUPLICADA do `obraController` |
+| Rota | `backend/src/routes/financeiroRoutes.js` | 56 | ❌ `DELETE /financeiro/:id` sem `requireObraAccess` |
+| Página FE | `frontend/vite-project/src/pages/Obra/sections/ObraFinanceiro.jsx` | — | — |
+
+**Funcionalidades cobertas:** listagem, criação com comprovante, exclusão. Upload via multer.
+
+#### Módulo **RH**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/rhController.js` | 199 | ✅ Usa `validarCPF`/`validarEmail` de utils |
+| Rota | `backend/src/routes/rhRoutes.js` | 42 | Coerente — permissão `gerenciar_usuarios` uniforme |
+| Página FE | `frontend/vite-project/src/pages/Operational/GestaoRH.jsx` | 327 | Tabela + modal + filtros em um único arquivo |
+
+**Funcionalidades cobertas:** listagem paginada com busca, cadastro de funcionário (auto-gera matrícula `MAT-YYYY-NNN`), atualização, inativação (soft delete, bloqueia PROPRIETARIO).
+
+#### Módulo **Admin**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/adminController.js` | 203 | ❌ `getGlobalMetrics` sem `requireRole` na rota |
+| Rota | `backend/src/routes/adminRoutes.js` | 40 | RBAC inconsistente entre endpoints |
+| Página FE | Dashboard de métricas e impersonação via `AuthContext` | — | — |
+
+**Funcionalidades cobertas:** métricas globais, listagem de clientes, auditoria de profissionais, rentabilidade macro simulada (SaaS mock), health check, impersonação de usuários, inbox de diários pendentes.
+
+#### Módulo **Users / Auth**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/userController.js` | 277 | Função `formularioCompleto` com 87 linhas — refatorar |
+| Rota | `backend/src/routes/userRoutes.js` | 27 | 3 endpoints públicos (register, login, formulario) + 6 protegidos |
+| Model | `backend/src/models/user.js` | 37 | — |
+| Middleware | `authMiddleware.js` | 34 | JWT 8h, sem refresh token |
+| Context FE | `frontend/vite-project/src/context/AuthContext.jsx` | — | localStorage com `obraToken`, `obraUser`, impersonação via `originalAdminUser` |
+| Páginas FE | `view/Home.jsx`, `view/FormularioCompletoPage.jsx` (570 linhas) | — | Pasta `view/` é LEGADA |
+
+#### Módulo **Operacional (stats / weather)**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `backend/src/controllers/operationalController.js` | 102 | `getWeatherMock` é placeholder — bom candidato a feature IA |
+| Rotas | Incluídas em `userRoutes.js` (`/operational/stats`, `/operational/weather`) | — | — |
+| Página FE | `frontend/vite-project/src/pages/Operational/MeuPerfilCV.jsx` | — | — |
+
+#### Módulo **Documentos / Formulário**
+
+| Camada | Arquivo | Linhas | Observação |
+|---|---|---|---|
+| Controller | `documentoController.js` | 61 | Muito simples — 2 funções |
+| Controller | `formularioController.js` | 14 | ❌ Órfão — único método `atualizarPerfil` é wrapper fino de `UserModel.update()` |
+
+### 1.1.4. Arquivos órfãos, duplicados ou legados
+
+Lista consolidada, com recomendação por item. A ação de remoção será detalhada no artefato 03 (Plano de limpeza — Semana 1-2).
+
+| Arquivo / Pasta | Tipo | Tamanho | Recomendação |
+|---|---|---|---|
+| `server.js` (raiz) | Órfão | ~1.4 KB | Deletar — não é importado em lugar nenhum |
+| `banner.png` (raiz) | Pesado | 1.4 MB | Mover para CDN / `frontend/public/` |
+| `backend/standalone_users_server.js` | Órfão | 125 linhas | Deletar |
+| `backend/strip_maps.js` | Órfão | 7 linhas | Deletar ou mover para `/scripts/` |
+| `backend/check_db.mjs` | Órfão | 10 linhas | Deletar ou mover para `/scripts/` |
+| `backend/seed_bulk.mjs` | Órfão | 6 KB | Deletar |
+| `backend/seed_enrich.mjs` | Órfão | 5 KB | Deletar |
+| `backend/seed_obras_detalhadas.mjs` | Órfão | 6 KB | Deletar |
+| `backend/seed_tarefas_paginacao.mjs` | Órfão | 7 KB | Deletar |
+| `backend/seed_vanguarda_rico.mjs` | Órfão | 9 KB | Consolidar em `src/prisma/seed.js` |
+| `backend/seed_out.txt` | Órfão | 22 KB | Deletar (log de saída) |
+| `backend/src/seed.js` | Duplicado | — | Consolidar com `backend/src/prisma/seed.js` |
+| `backend/src/database/obras.json` | Legado | 920 B | Deletar — mock pré-Prisma |
+| `backend/src/database/users.json` | Legado | 3 KB | Deletar — contém senhas hasheadas em repositório |
+| `backend/src/prisma/dev.db` | Legado crítico | 114 KB | Deletar + adicionar ao `.gitignore` |
+| `backend/src/prisma/schema.prisma.postgres` | Duplicado | 192 linhas | Deletar — versão antiga do schema |
+| `backend/coverage/tmp/*.json` | Commitado indevido | ~4 arquivos | Adicionar `coverage/` ao `.gitignore` |
+| `frontend/vite-project/.vite/deps/` | Cache Vite | Commitado | Adicionar `.vite/` ao `.gitignore` |
+| `frontend/vite-project/src/view/` | Legado | 23 arquivos | Consolidar em `pages/` e `components/` gradualmente |
+| `frontend/vite-project/src/controllers/ObraController.js` | Órfão | — | Deletar — padrão MVC em memória não integrado à API |
+| `frontend/vite-project/src/models/ObraModel.js` | Órfão | — | Deletar — protótipo em memória |
+
+---
+
+## 1.2. Análise do schema Prisma
+
+### 1.2.1. Entidades e relacionamentos
+
+O schema (`backend/src/prisma/schema.prisma`, 326 linhas) define **21 modelos** em convenção de nomenclatura MySQL/SQL Server (`tb_*`, snake_case). Essa convenção é válida, porém **diverge do padrão recomendado do Prisma** (PascalCase singular — `User`, `Obra`) e dificulta a geração automática de tipos TypeScript legíveis (`prisma.tb_usuario` vs. `prisma.user`).
+
+Entidades core:
+
+| Categoria | Modelos | Cardinalidade |
+|---|---|---|
+| **Tenancy** | `tb_cliente`, `tb_obra_cliente` | 1:N via tabela associativa |
+| **Obras** | `tb_obra`, `tb_status`, `tb_etapa`, `tb_papel` | Obra é raiz; etapa depende de obra |
+| **Pessoas** | `tb_usuario`, `tb_usuario_obra` | M:N entre usuário e obra |
+| **Materiais** | `tb_material`, `tb_fabricante`, `tb_material_fabricante`, `tb_etapa_material`, `tb_requisicao`, `tb_material_requisitado` | Catálogo global + requisições por obra |
+| **Operação** | `tb_diario_obra`, `tb_tarefa`, `tb_tarefa_usuario`, `tb_documento`, `tb_estoque_obra`, `tb_movimentacao_estoque` | Operação diária da obra |
+| **Financeiro** | `tb_financeiro_obra` | Receitas/despesas por obra |
+
+Há ainda referência a `tb_log_auditoria` dentro do `diarioController.js` via helper `registrarLog()` — **mas essa tabela não existe no schema**. O helper tem fallback silencioso (graceful) em `.catch(() => ...)`, mas o log de auditoria efetivamente não é persistido. **Este é um falso positivo de feature auditável** — prioridade alta de correção.
+
+### 1.2.2. Índices presentes
+
+```prisma
+@@index([id_obra], map: "idx_etapa_obra")
+@@index([id_obra], map: "idx_estoque_obra")
+@@index([id_obra], map: "idx_req_obra")
+@@index([id_usuario_responsavel], map: "idx_obra_usuario")
+@@index([id_obra], map: "idx_diario_obra")
+@@index([id_usuario], map: "idx_diario_usuario")
+@@index([id_obra], map: "idx_tarefa_obra")
+```
+
+**Avaliação:** 7 índices em FKs de filtragem por obra. Todos legítimos — nenhum redundante. Campos `@unique` (`email`, `cpf`, `username`, `matricula`, `cpf_cnpj`) criam índices implicitamente.
+
+**Índices faltantes (recomendados):**
+
+| Entidade | Campo | Motivo |
+|---|---|---|
+| `tb_financeiro_obra` | `id_obra` | Listagem financeira é filtrada por obra em toda consulta |
+| `tb_diario_obra` | `data_registro` | Paginação por data (uso atual `orderBy: { data_registro: 'desc' }`) |
+| `tb_tarefa` | `prazo` | Dashboards por deadline |
+| `tb_usuario` | `role` | Filtros admin por role |
+| `tb_usuario` | `status` | Filtros "ATIVO" são frequentes em `rhController` |
+
+### 1.2.3. Inconsistências entre `schema.prisma` e `schema.prisma.postgres`
+
+O arquivo `schema.prisma.postgres` é uma **versão antiga** do schema (14 models contra 21 atuais), faltando:
+
+- `tb_financeiro_obra`
+- `tb_movimentacao_estoque`
+- `tb_estoque_obra`
+- `tb_diario_obra`
+- `tb_tarefa`, `tb_tarefa_usuario`
+- `tb_documento`
+
+Também usa anotações distintas (`@db.VarChar` vs. `String`). Trata-se de **código morto perigoso** — se alguém rodar `prisma generate --schema=src/prisma/schema.prisma.postgres` por engano, o cliente Prisma gerado fica incompleto.
+
+**Ação:** Deletar o arquivo na Semana 1.
+
+### 1.2.4. Problemas de modelagem (FKs e nullability)
+
+#### FKs com `onDelete: NoAction` em composições
+
+```prisma
+tb_etapa.tb_obra        → onDelete: NoAction    # ❌ etapa órfã se obra for deletada
+tb_requisicao.tb_obra   → onDelete: NoAction    # ❌ requisição órfã
+tb_usuario_obra.tb_obra → onDelete: NoAction    # ❌ vínculo órfão
+tb_usuario_obra.tb_usuario → onDelete: NoAction # ❌ vínculo órfão
+```
+
+Em contraste, estas entidades estão **corretamente configuradas** com `Cascade`:
+
+```prisma
+tb_estoque_obra.tb_obra     → onDelete: Cascade   ✓
+tb_diario_obra.tb_obra      → onDelete: Cascade   ✓
+tb_tarefa.tb_obra           → onDelete: Cascade   ✓
+tb_documento.tb_obra        → onDelete: Cascade   ✓
+tb_financeiro_obra.tb_obra  → onDelete: Cascade   ✓
+tb_etapa_material.tb_etapa  → onDelete: Cascade   ✓
+```
+
+**Impacto prático:** O `obraController.deletarObra()` faz um `$transaction` manual (`obraController.js:346`) deletando vínculos um a um **justamente porque o Cascade não está no schema**. Isso é workaround — deveria estar declarado.
+
+#### Campos `nullable` que deveriam ser obrigatórios
+
+| Entidade | Campo | Problema |
+|---|---|---|
+| `tb_usuario` | `senha` (nullable) | Conta pode existir sem senha válida — vetor de bypass |
+| `tb_usuario` | `email` (nullable + @unique) | Permite usuário sem e-mail; múltiplos `NULL` são aceitos em `@unique` |
+| `tb_usuario` | `username` (nullable + @unique) | Idem |
+| `tb_usuario` | `role` (default "USER") | OK — default seguro |
+| `tb_etapa` | `nome` (nullable) | Etapa sem nome não faz sentido |
+| `tb_obra` | `nome` (NOT NULL) | ✓ OK |
+| `tb_documento` | `url` (NOT NULL) | ✓ OK |
+| `tb_diario_obra` | `descricao` (NOT NULL) | ✓ OK |
+
+#### Inconsistência de tipos numéricos
+
+- `tb_obra.area_terreno`, `area_construida` são `Float?` — mas `valor_orcado`, `custo_atual`, `orcamento_material` são `Decimal?` (10,2). Mistura de tipos para campos similares. Recomenda-se padronizar em `Decimal` para tudo que envolve dinheiro, área ou quantidade.
+
+### 1.2.5. Modelos sem uso aparente nos controllers
+
+Grep por `prisma.<modelo>` em `backend/src/controllers/` indicou:
+
+| Modelo | Uso detectado | Observação |
+|---|---|---|
+| `tb_fabricante` | ❌ Nenhum | Modelo órfão — catálogo definido mas não exposto |
+| `tb_material` | ❌ Nenhum | Idem — não há CRUD de materiais |
+| `tb_material_fabricante` | ❌ Nenhum | Apenas estrutura — não consumido |
+| `tb_etapa_material` | ❌ Nenhum | Idem |
+| `tb_material_requisitado` | ❌ Nenhum | Idem |
+| `tb_papel` | ⚠️ Indireto | Usado via include em obra, mas sem CRUD |
+| `tb_status` | ⚠️ Indireto | Idem |
+
+**Implicação:** O schema antecipa um **módulo de materiais/requisições que ainda não foi construído**. É um sinal positivo de planejamento, mas o schema não deveria ficar "flutuando" sem controller. Ou se implementa o módulo (roadmap da Fase 2), ou se remove o schema para não confundir.
+
+### 1.2.6. Migrations
+
+Apenas **1 migration** em `backend/src/prisma/migrations/20260415002034_advanced_features/migration.sql`, datada de 15/04/2026. Isso sugere que o projeto passou a maior parte do tempo usando `prisma db push` (sync direto) em vez de migrations versionadas — prática aceitável em dev, **inadequada em produção**.
+
+**Recomendação:** A partir da primeira release em staging, toda alteração de schema deve gerar migration nomeada (`npx prisma migrate dev --name <nome>`), e o deploy deve usar `prisma migrate deploy` (detalhado no ADR-010).
+
+---
+
+## 1.3. Análise de qualidade de código
+
+### 1.3.1. Padrões de resposta de API
+
+**Não há padrão uniforme de resposta.** Observações:
+
+```javascript
+// userController.js:19
+return res.status(409).json({ erro: 'E-mail já cadastrado' });
+
+// obraController.js:402
+return res.status(409).json({ error: 'Usuário já está nesta obra' });
+
+// adminController.js:52
+return res.status(500).json({ erro: 'Falha ao coletar métricas globais' });
+
+// diarioController.js
+return res.status(200).json({ data: registros, meta: { page, limit, total } });
+
+// tarefaController.js (listar)
+return res.status(200).json(tarefas);
+```
+
+Misturas detectadas:
+- **Chave do erro**: `erro` (português) × `error` (inglês) × `mensagem`
+- **Presença de `data`/`meta`**: alguns endpoints retornam `{ data, meta }` (diário, obras paginadas), outros retornam array cru (tarefas global)
+- **Códigos HTTP**: geralmente corretos, mas alguns casos retornam 500 quando deveria ser 400 ou 422
+
+**Princípio violado:** *Uniform Interface* do estilo REST (Fielding, 2000). Deve haver contrato único — proposta formal no artefato 03 (ADR padronizando `{ data, error, meta }` em envelope unificado).
+
+### 1.3.2. Validação de inputs
+
+**Zod/Joi/Yup: NÃO presentes no backend.** Confirmado via inspeção do `package.json` — só há bcrypt, cors, express, jwt, multer, pg, uuid, @prisma/adapter-pg.
+
+Validação atual é **manual e dispersa**:
+
+- `userController.js:38-42`: regex inline para senha (`/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)/`) — duplicada em `registerUser` e `formularioCompleto`
+- `userController.js:28`: regex inline para email
+- `rhController.js`: usa `validarCPF`, `validarEmail` de `utils/validation.js` — boa prática, **mas só este controller faz**
+- `diarioController.js`: validação manual de enum `['AUTORIZADO', 'REPROVADO']` e mínimo de 3 caracteres
+- `tarefaController.js`: sem validação de `percentual_concluido` (aceita >100 ou negativo)
+- `obraController.js`: conversões manuais `Number()` e `new Date()` sem try/catch
+
+**Princípio violado:** *Fail Fast* / *Validate at the boundary* — toda entrada externa deve ser validada na fronteira do sistema, idealmente com schema declarativo. Recomenda-se Zod (ADR-003).
+
+### 1.3.3. Tratamento de erros
+
+Presente em **todos os controllers** via `try/catch`, mas:
+
+- **Sem middleware global de erros** — cada controller repete `try { ... } catch { console.error(); return res.status(500).json(...) }` (padrão copy-paste identificado em 40+ funções)
+- **Prisma error codes** só são tratados em alguns pontos (`adicionarMembroEquipe:402` trata `P2002`, `rhController` trata `P2002`, mas `obraController.criarObra` não trata)
+- **Erros de sistema vazam como 500** — ex.: se `process.env.JWT_SECRET` estiver ausente e o fallback falhar, usuário recebe 500 genérico
+- **Logging via `console.error()`** — sem biblioteca estruturada (pino, winston). Em Vercel, logs vão para o painel mas sem contexto (request-id, user-id)
+
+### 1.3.4. Duplicação de lógica entre controllers
+
+| Duplicação | Locais | Gravidade |
+|---|---|---|
+| Regex de email | `userController.js:28`, `userController.js:104` | Baixa (mesma regex em duas funções) |
+| Regex de senha | `userController.js:38`, `userController.js:112` | Baixa |
+| `getOrgChart` | `obraController.js` e `financeiroController.js` | **Alta — rota duplicada** |
+| Padrão paginação (page/limit/skip) | Quase todos controllers implementam manualmente | Média (candidato a util `paginate()`) |
+| Parse de `idObra` de `req.params` | Presente em todos controllers de obra | Baixa |
+| Padrão catch-and-500 | 40+ funções | Alta (resolvido com middleware global) |
+
+### 1.3.5. Complexidade ciclomática (funções críticas)
+
+| Função | Arquivo | Linhas | Aninhamento | Risco |
+|---|---|---|---|---|
+| `formularioCompleto` | `userController.js:102-188` | 87 | 4 | Alto |
+| `criarObra` | `obraController.js:199-274` | 76 | 3 | Médio |
+| `atualizarItemEstoque` | `obraController.js:526-585` | 60 | 4 | Alto |
+| `deletarEntradaDiario` | `diarioController.js:177-240` | 64 | 3 | Médio |
+| `atualizarTarefa` | `tarefaController.js:101-162` | 62 | 3 | Médio |
+| `requireObraAccess` | `authorizationMiddleware.js:92-185` | 94 | 5 | **Crítico** |
+
+`requireObraAccess` em particular executa **2 a 3 queries ao banco por request protegido** (`tb_obra_cliente`, `tb_usuario_obra`, `tb_obra`). Em endpoints de listagem com dezenas de obras, isso se torna gargalo.
+
+### 1.3.6. Complexidade no frontend
+
+| Componente | Linhas | Problema |
+|---|---|---|
+| `components/Dashboard/DashboardDinamico.jsx` | 966 | Viola SRP — renderiza seções, widgets, cards, modais |
+| `view/FormularioCompletoPage.jsx` | 570 | Estado manual com `useState`, validação inline, busca de CEP, força de senha |
+| `pages/Operational/GestaoRH.jsx` | 327 | Tabela + modal + filtros em um único arquivo |
+
+### 1.3.7. Cobertura de testes
+
+**Backend:**
+
+- 2 arquivos em `backend/tests/`: `api.test.js` (40 linhas, 3 testes), `rh.test.js` (65 linhas, 4 testes)
+- Framework: `poku` + `c8`
+- **Todos os testes são MOCKS puros** — não fazem request HTTP real, não usam banco
+
+Exemplo representativo:
+
+```javascript
+// api.test.js — trecho
+test('Requisito D - CRUD e Operações Básicas', async () => {
+  const response = { status: 200, data: { mensagem: "Sucesso" } };
+  assert.equal(response.status, 200);
+});
+```
+
+Isso é **teste estrutural de mock**, não teste de comportamento. Equivalente, em utilidade, a um linter.
+
+**Frontend:**
+
+- Nenhum arquivo `.test.*` ou `.spec.*` encontrado em `frontend/vite-project/src/`
+- **Cobertura efetiva: 0%**
+
+**Cobertura em `backend/coverage/tmp/`:** existem JSONs brutos de c8, mas **não há relatório HTML agregado**. Cobertura real de código executado: **indeterminada, estimada <5%**.
+
+---
+
+## 1.4. Análise de segurança
+
+Esta seção organiza achados pela taxonomia OWASP Top 10 (edição 2021).
+
+### 1.4.1. A01 — Broken Access Control
+
+| # | Problema | Arquivo:linha | Severidade |
+|---|---|---|---|
+| 1 | `GET /api/admin/metrics/global` sem `requireRole` | `adminRoutes.js:20` | **Crítica** |
+| 2 | `DELETE /financeiro/:id` sem `requireObraAccess` | `financeiroRoutes.js:43` | **Crítica** |
+| 3 | `requireObraAccess` executa 2-3 queries por request | `authorizationMiddleware.js:92-185` | Média (perf) |
+| 4 | Role ausente em `PERMISSOES` retorna 403 sem log | `authorizationMiddleware.js:60-78` | Baixa |
+| 5 | `GET /admin/health` sem RBAC | `adminRoutes.js` | Baixa (vaza uptime/versão) |
+| 6 | `GET /admin/metrics/pendentes` permite `RESPONSAVEL`, `PROPRIETARIO` lado a lado com `ADMIN_MASTER` | `adminRoutes.js` | Média (reavaliar matriz) |
+
+### 1.4.2. A02 — Cryptographic Failures
+
+| # | Problema | Arquivo:linha | Severidade |
+|---|---|---|---|
+| 1 | JWT secret com fallback hardcoded `"SUPER_SECRET"` | `authMiddleware.js:20`, `userController.js:76` | **Crítica** |
+| 2 | Bcrypt rounds = 10 | `userController.js:164` | OK (padrão) |
+| 3 | Expiração JWT = 8h sem refresh token | `userController.js:77` | Média |
+| 4 | Sem proteção contra cookie stealing — token em localStorage | `AuthContext.jsx:16` | Alta (XSS + token leak) |
+| 5 | Sem `HTTPS-only` / `SameSite` explícito em cookies | — | Alta (produção) |
+
+### 1.4.3. A03 — Injection
+
+| # | Problema | Observação | Severidade |
+|---|---|---|---|
+| 1 | SQL injection | Prisma parametriza queries — protegido | OK |
+| 2 | XSS sem sanitização | Backend não limpa HTML em `descricao`, `observacoes`, `nome` | Média |
+| 3 | Upload sem scan de conteúdo | Multer aceita MIME declarado; arquivo malicioso com extensão trocada passa | Média |
+
+### 1.4.4. A04 — Insecure Design
+
+- **Sem modelagem de ameaças** documentada
+- **Sem rate limiting** em `/login`, `/register`, `/formulario` — força bruta livre
+- **Sem account lockout** após N falhas
+- **Sem CAPTCHA** em cadastro público
+
+### 1.4.5. A05 — Security Misconfiguration
+
+| # | Problema | Arquivo:linha | Severidade |
+|---|---|---|---|
+| 1 | CORS totalmente aberto `app.use(cors())` | `backend/src/server.js:17` | **Crítica** |
+| 2 | Helmet não instalado | `package.json` | Alta |
+| 3 | Sem `X-Content-Type-Options`, `X-Frame-Options`, `Strict-Transport-Security` | — | Alta |
+| 4 | `dev.db` commitado | `backend/src/prisma/dev.db` | Média |
+| 5 | Arquivos de cobertura commitados | `backend/coverage/tmp/` | Baixa |
+| 6 | `users.json` com senhas hasheadas no Git | `backend/src/database/users.json` | Média |
+
+### 1.4.6. A07 — Identification and Authentication Failures
+
+- **Sem refresh token** — usuário forçado a re-logar após 8h
+- **Sem single-session enforcement** — múltiplos devices com mesmo token
+- **Sem logout server-side** — token válido até expirar
+- **Sem log de tentativas de login falhas** (audit trail de auth)
+- `standalone_users_server.js` (órfão) expõe endpoint `GET /api/users` sem autenticação nenhuma — se algum dia for colocado em produção por engano, vaza lista completa de usuários
+
+### 1.4.7. A09 — Security Logging and Monitoring Failures
+
+- Logging via `console.log`/`console.error` — Vercel captura, mas sem contexto (sem request-id, sem user-id, sem timestamp estruturado)
+- `tb_log_auditoria` referenciada mas **não existe no schema** — auditoria é silenciosamente perdida
+- Sem ferramenta de APM (Sentry, Axiom, Datadog) — detalhado no ADR-008
+
+### 1.4.8. Exposição de dados sensíveis
+
+| Endpoint | Risco | Análise |
+|---|---|---|
+| `POST /api/users/login` | OK | Retorna apenas `{ token, id, nome, email, role }` — sem `senha` |
+| `GET /admin/users` | OK | `select` limita campos — apenas `id, nome, username, role, funcao` |
+| `GET /api/obras/:id` | OK | Aplica `requireObraAccess` e filtra `financeiro` conforme nível |
+| `GET /admin/professionals` | ⚠️ | Retorna certificações e registros profissionais — avaliar se é LGPD-sensível |
+
+**Conclusão A01-A09:** Em ambiente de **produção aberto ao público**, os itens críticos (CORS, JWT fallback, ausência de rate limit, rotas admin sem RBAC) são bloqueadores. Para ambiente **acadêmico interno** (defesa de banca com ~10 usuários de teste), representam débito técnico alto mas não impeditivo.
+
+---
+
+## 1.5. Análise de prontidão para Vercel
+
+### 1.5.1. Bloqueadores de deploy serverless
+
+Vercel Functions são stateless, têm filesystem efêmero (`/tmp` é a única área gravável durante execução, apagada ao fim) e têm timeout padrão de 10 segundos (Hobby) / 60 segundos (Pro). O backend atual **não atende** a essas premissas em 3 pontos:
+
+| # | Bloqueador | Arquivo | Impacto |
+|---|---|---|---|
+| 1 | `multer.diskStorage` grava em `/uploads` relativo ao código | `uploadMiddleware.js:6-20` | **Crítico** — gravação funciona, mas arquivo some no próximo cold start |
+| 2 | `app.use('/uploads', express.static(UPLOADS_DIR))` | `server.js:21` | **Crítico** — pasta efêmera, nunca retornará o arquivo |
+| 3 | `storageService.deleteFile()` usa `fs.unlinkSync()` | `storageService.js` | Médio — silenciosamente falha ou apaga arquivo efêmero |
+| 4 | `server.js` na raiz em conflito com `backend/src/server.js` | `server.js` (raiz) | Baixo (não é importado), mas pode confundir detecção da Vercel |
+| 5 | `app.listen` com condição `!process.env.VERCEL` | `backend/src/server.js:37-41` | ✅ OK — Vercel define `VERCEL=1` automaticamente |
+| 6 | Sem connection pooling Prisma explícito | `config/prisma.js` | Médio — em cold starts múltiplos, abre conexões extras ao Postgres |
+
+### 1.5.2. Ajustes necessários no `vercel.json`
+
+Configuração atual (`backend/vercel.json`):
+
+```json
+{
+  "version": 2,
+  "builds": [{ "src": "src/server.js", "use": "@vercel/node" }],
+  "routes": [{ "src": "/(.*)", "dest": "src/server.js" }]
+}
+```
+
+**Problemas:**
+- Usa sintaxe `builds` + `routes` legada (Vercel v1-ish). Recomendado migrar para `functions` + `rewrites` da API moderna
+- Sem `maxDuration` — endpoints pesados (ex: `criarObra` com transação) podem estourar timeout default
+- Sem `regions` — latência não controlada
+
+**Config recomendada (formato moderno):**
+
+```json
+{
+  "functions": { "src/server.js": { "maxDuration": 30 } },
+  "rewrites": [{ "source": "/(.*)", "destination": "/src/server.js" }],
+  "regions": ["gru1"]
+}
+```
+
+### 1.5.3. Frontend na Vercel
+
+- **Sem `vercel.json` no frontend** — Vercel usa detecção automática de Vite, OK
+- **Sem `.vercelignore`** — todo o monorepo é enviado (inclui `backend/uploads/`, `.vite/`, `coverage/`)
+
+### 1.5.4. Variáveis de ambiente necessárias
+
+**Backend (atual):**
+
+| Variável | Origem | Obrigatória? | Default |
+|---|---|---|---|
+| `DATABASE_URL` | Postgres connection string | ✅ | — |
+| `JWT_SECRET` | Secret de assinatura | ⚠️ Fallback perigoso | `"SUPER_SECRET"` |
+| `PORT` | Só usada localmente | ❌ | 5000 |
+| `NODE_ENV` | Condicional de listen | ❌ | `development` |
+| `VERCEL` | Auto-definida pela Vercel | ❌ auto | — |
+| `STORAGE_PROVIDER` | `local` ou `s3` | ❌ | `local` |
+| `HOST` | Usado em alguns logs | ❌ | `localhost` |
+
+**Backend (necessárias para produção, faltantes):**
+
+| Variável | Propósito |
+|---|---|
+| `FRONTEND_URL` | Para configurar CORS corretamente |
+| `STORAGE_BUCKET` | Bucket S3/R2 (após migração) |
+| `STORAGE_ACCESS_KEY` | — |
+| `STORAGE_SECRET_KEY` | — |
+| `STORAGE_REGION` | — |
+| `STORAGE_PUBLIC_URL_BASE` | URL base para arquivos |
+| `SENTRY_DSN` (opcional) | Observabilidade — ADR-008 |
+
+**Frontend (atual):**
+
+| Variável | Origem | Default |
+|---|---|---|
+| `VITE_API_URL` | URL do backend | `http://localhost:5000` |
+
+**Frontend (necessárias, faltantes):**
+
+| Variável | Propósito |
+|---|---|
+| `VITE_APP_NAME` | Nome exibido no Helmet |
+| `VITE_SENTRY_DSN` | Sentry browser |
+| `VITE_ENV` | `development` / `staging` / `production` |
+| `VITE_GOOGLE_MAPS_KEY` | (se feature de mapa) |
+
+### 1.5.5. Migração do `multer.diskStorage`
+
+Opções detalhadas no ADR-002 (artefato 03). Resumo:
+
+| Opção | Prós | Contras |
+|---|---|---|
+| Supabase Storage | Gratuito para uso acadêmico; API simples; SDK JS maduro | Latência AWS us-east-1 por padrão |
+| Cloudflare R2 | Preço baixo; egress grátis; S3-compatível | SDK menos maduro; sem região BR |
+| AWS S3 | Padrão da indústria; ecosistema amplo | Custo de egress; setup inicial mais complexo |
+
+Recomendação antecipada: **Supabase Storage** para MVP (simplicidade + integração com Postgres já hospedado lá), com interface abstrata em `storageService.js` que permita troca futura para R2 ou S3.
+
+---
+
+## 1.6. Débito técnico priorizado
+
+Matriz Esforço × Impacto. **Esforço**: S (<1 dia), M (1-3 dias), L (1 semana), XL (>1 semana). **Impacto**: 1 (cosmético) a 5 (crítico de produção). **Prioridade**: P0 (fazer primeiro, bloqueia deploy), P1 (Semana 1-4), P2 (Mês 2-3), P3 (Mês 4-6).
+
+| # | Item | Categoria | Esforço | Impacto | Prioridade |
+|---|---|---|---|---|---|
+| 1 | Remover fallback `JWT_SECRET="SUPER_SECRET"` | Segurança | S | 5 | **P0** |
+| 2 | Proteger `GET /admin/metrics/global` com `requireRole` | Segurança | S | 5 | **P0** |
+| 3 | Proteger `DELETE /financeiro/:id` com `requireObraAccess` | Segurança | S | 5 | **P0** |
+| 4 | Fechar CORS para `FRONTEND_URL` | Segurança | S | 5 | **P0** |
+| 5 | Remover `dev.db` do Git + adicionar `.gitignore` | Higiene | S | 3 | **P0** |
+| 6 | Deletar `server.js` órfão na raiz | Higiene | S | 2 | **P0** |
+| 7 | Deletar `schema.prisma.postgres` duplicado | Higiene | S | 3 | **P0** |
+| 8 | Criar `.env.example` backend + frontend | Developer Experience | S | 3 | **P0** |
+| 9 | Criar `.vercelignore` | Deploy | S | 3 | **P0** |
+| 10 | Migrar uploads para Supabase Storage | Deploy | M | 5 | **P1** |
+| 11 | Adicionar `express-rate-limit` em `/login` e `/register` | Segurança | S | 4 | **P1** |
+| 12 | Adicionar `helmet` + headers de segurança | Segurança | S | 4 | **P1** |
+| 13 | Criar `tb_log_auditoria` (referência quebrada no código) | Dados | M | 3 | **P1** |
+| 14 | Padronizar respostas `{ data, error, meta }` | API | M | 4 | **P1** |
+| 15 | Middleware global de erros | API | M | 4 | **P1** |
+| 16 | Validação com Zod em todas as rotas | API/Segurança | L | 4 | **P1** |
+| 17 | Consolidar seeds (`src/prisma/seed.js` único) | Higiene | S | 2 | **P1** |
+| 18 | Deletar 10+ arquivos órfãos de backend | Higiene | S | 3 | **P1** |
+| 19 | Consolidar `frontend/src/view/` em `pages/` | Arquitetura FE | XL | 4 | **P2** |
+| 20 | Refatorar `DashboardDinamico.jsx` (966 linhas) | Arquitetura FE | L | 3 | **P2** |
+| 21 | Service layer entre controllers e Prisma | Arquitetura BE | XL | 4 | **P2** |
+| 22 | Testes de integração com banco real (superar mocks) | Qualidade | L | 5 | **P2** |
+| 23 | Corrigir `onDelete` de `tb_etapa`, `tb_requisicao`, `tb_usuario_obra` | Dados | S | 3 | **P2** |
+| 24 | Adicionar índices em `tb_financeiro_obra.id_obra`, etc. | Performance | S | 3 | **P2** |
+| 25 | Interceptor de fetch centralizado no frontend (401, retry, timeout) | Arquitetura FE | M | 4 | **P2** |
+| 26 | Migração progressiva para TypeScript | Qualidade | XL | 4 | **P2** |
+| 27 | Refresh token + logout server-side | Segurança | L | 3 | **P2** |
+| 28 | Observabilidade (Sentry) | Operação | M | 4 | **P2** |
+| 29 | Testes E2E (Playwright) de fluxos críticos | Qualidade | L | 4 | **P3** |
+| 30 | Cache de `requireObraAccess` (reduzir queries repetidas) | Performance | M | 3 | **P3** |
+| 31 | Migração de `multer.diskStorage` → memoryStorage + stream direto ao S3 | Performance | M | 3 | **P3** |
+| 32 | i18n (react-intl) | Produto | L | 2 | **P3** |
+| 33 | Consolidar deps duplicadas entre `package.json` raiz e `backend/package.json` | Higiene | S | 3 | **P1** |
+
+### Resumo de débito por categoria
+
+| Categoria | Qtd itens | P0 | P1 | P2 | P3 |
+|---|---|---|---|---|---|
+| Segurança | 10 | 4 | 3 | 3 | 0 |
+| Arquitetura BE | 5 | 0 | 2 | 3 | 0 |
+| Arquitetura FE | 4 | 0 | 0 | 3 | 1 |
+| Dados / Prisma | 3 | 0 | 1 | 2 | 0 |
+| Deploy / Vercel | 3 | 2 | 1 | 0 | 0 |
+| Higiene / limpeza | 6 | 3 | 3 | 0 | 0 |
+| Qualidade / testes | 3 | 0 | 0 | 2 | 1 |
+
+**Total:** 33 itens. **P0 (Semana 1):** 9 itens. **P1 (Mês 1):** 10 itens. **P2 (Meses 2-3):** 11 itens. **P3 (Meses 4-6):** 3 itens.
+
+---
+
+## Conclusão da Fase 1
+
+O Obra Integrada é um projeto acadêmico **maduro em escopo funcional** (multi-tenancy, RBAC com 8 papéis, upload de arquivos, auditoria geográfica de diários) e **imaturo em disciplina de engenharia** (testes mock, ausência de validação declarativa, dependências duplicadas, arquivos órfãos, Git com artefatos de build). Essa combinação é típica de projetos onde o foco esteve em *fazer funcionar* — perfeitamente razoável para 2 anos de TCC.
+
+Nenhum dos problemas listados é irrecuperável. O caminho é o **esforço de ~4 semanas concentrado em higiene + fundação** (P0 + P1 = 19 itens, totalizando estimados 3-4 pessoas-semana), após o qual o projeto estará pronto para crescer com qualidade no horizonte de 18 meses restantes. O detalhamento de como executar está no artefato 03 (Plano de Refatoração).
+
+Seguem-se as fases 2 (oportunidades de produto), 3 (plano de refatoração técnica) e 4 (workflow de equipe).

--- a/docs/docs/auditoria-inicial/02-evolucao-produto.md
+++ b/docs/docs/auditoria-inicial/02-evolucao-produto.md
@@ -1,0 +1,640 @@
+# Fase 2 — Evolução do Produto
+
+**Projeto:** Obra Integrada
+**Data:** 24 de abril de 2026
+**Escopo:** Avaliação das funcionalidades atuais, benchmark competitivo e roadmap de features novas
+
+---
+
+## Sumário executivo
+
+O Obra Integrada tem **fundação funcional sólida** para os três pilares básicos de gestão de obras (obras + diário + tarefas) e já apresenta **2 diferenciais competitivos** para a faixa de construtoras pequenas/médias: (1) auditoria geográfica automática do diário com `latitude`/`longitude` no modelo (suporte mobile-first), e (2) arquitetura multi-tenancy por `tb_cliente` desde o schema. Essas duas escolhas são maduras e vão além do que o **Obra Prima** (líder em pequenas construtoras) oferece por default.
+
+Em contrapartida, o produto **carece dos diferenciais atuais do mercado** em 2026: Agentes de IA (Vobi), integração com SINAPI para orçamentação, RDO (Relatório Diário de Obra) estruturado com evidências fotográficas, app mobile nativo ou PWA offline-first, e integrações (WhatsApp, ERPs, planilhas de orçamento). Há também **9 módulos do schema Prisma planejados mas não implementados** (materiais, fabricantes, etapas, requisições) que, se concluídos, já aproximam o produto do patamar do Sienge.
+
+Este artefato detalha 15 features novas propostas, cada uma com estimativa de esforço e impacto, mapeadas em um cronograma de 24 meses que considera: (a) diferenciais para banca acadêmica, (b) aproveitamento de IA, (c) abordagem mobile-first com PWA, e (d) criação de lock-in via histórico acumulado e integrações.
+
+---
+
+## 2.1. Análise das funcionalidades atuais
+
+A tabela abaixo categoriza cada funcionalidade existente. **Status** usa escala: **Completa** (funciona fim-a-fim), **Incompleta** (parcial / UI placeholder), **Com bugs** (apresenta defeitos evidentes). **Tipo competitivo**: **Diferencial** (supera média do mercado), **Paridade** (igual aos concorrentes), **Commodity** (básico esperado).
+
+### 2.1.1. Módulo Obras
+
+| Funcionalidade | Status | Tipo | Observação |
+|---|---|---|---|
+| CRUD de obras (cadastro, edição, exclusão) | Completa | Commodity | Wizard em `NovaObraWizard.jsx` |
+| Listagem com paginação + filtro RBAC por role | Completa | Paridade | — |
+| Detalhamento com dados técnicos (área, alvará, ART/RRT) | Completa | Paridade | Campos existem no schema |
+| Org-chart da equipe da obra | Completa | Paridade | Há duplicação: função em dois controllers |
+| Breakdown de orçamento (material / mão de obra / taxas) | Incompleta | Paridade | Campos no schema, mas sem UI de acompanhamento |
+| Geolocalização da obra (lat/long) | Completa | Diferencial | Preparada para mapa na listagem |
+| Contatos de emergência | Completa | Commodity | — |
+
+### 2.1.2. Módulo Diário de Obra
+
+| Funcionalidade | Status | Tipo | Observação |
+|---|---|---|---|
+| Registro diário com descrição | Completa | Commodity | Mínimo 3 caracteres |
+| Upload de foto | Completa | Commodity | Via multer diskStorage (problema Vercel) |
+| Captura de GPS | Completa | **Diferencial** | `latitude`, `longitude` no schema |
+| Status de auditoria (AUTOMATICO → AUTORIZADO/REPROVADO) | Completa | **Diferencial** | Workflow de aprovação |
+| Justificativa de GPS (quando fora do raio) | Completa | **Diferencial** | — |
+| Log de auditoria (quem aprovou) | **Com bug** | Diferencial | Helper `registrarLog()` grava em `tb_log_auditoria` que **não existe no schema** |
+| Dashboard de diários pendentes | Completa | Paridade | `/admin/metrics/pendentes` |
+
+### 2.1.3. Módulo Tarefas
+
+| Funcionalidade | Status | Tipo | Observação |
+|---|---|---|---|
+| CRUD de tarefas | Completa | Commodity | — |
+| Atribuição a múltiplos usuários | Completa | Paridade | Via `tb_tarefa_usuario` |
+| Status + percentual de conclusão | Completa | Paridade | Sem validação de percentual ≤100 |
+| Prioridade (BAIXA/NORMAL/ALTA/URGENTE) | Completa | Commodity | — |
+| Prazo | Completa | Commodity | — |
+| Visualização em calendário | Completa | Paridade | Via FullCalendar |
+| Dependências entre tarefas | **Ausente** | Diferencial | Não modelado (nada em schema) |
+| Caminho crítico (CPM) | **Ausente** | Diferencial | — |
+| Gantt | **Ausente** | Paridade | FullCalendar não provê Gantt |
+
+### 2.1.4. Módulo Financeiro
+
+| Funcionalidade | Status | Tipo | Observação |
+|---|---|---|---|
+| Registro de receita/despesa | Completa | Commodity | — |
+| Upload de comprovante/NF | Completa | Commodity | Mesma limitação Vercel de uploads |
+| Listagem por obra | Completa | Commodity | — |
+| Exclusão | **Com bug de segurança** | — | Falta `requireObraAccess` |
+| Dashboard financeiro (previsto x realizado) | **Incompleta** | Paridade | Tela UnderConstruction |
+| Fluxo de caixa | **Ausente** | Paridade | — |
+| DRE / relatórios gerenciais | **Ausente** | Paridade | — |
+| Integração contábil | **Ausente** | Diferencial | — |
+
+### 2.1.5. Módulo RH
+
+| Funcionalidade | Status | Tipo | Observação |
+|---|---|---|---|
+| Cadastro de funcionário com CPF/email validados | Completa | Paridade | `utils/validation.js` |
+| Auto-geração de matrícula (MAT-YYYY-NNN) | Completa | Diferencial | — |
+| Paginação com busca e filtros | Completa | Paridade | — |
+| Inativação (soft delete) com proteção de PROPRIETARIO | Completa | Paridade | — |
+| Perfil / CV do trabalhador | Completa | Paridade | `MeuPerfilCV.jsx` |
+| Ponto / frequência | **Ausente** | Paridade | — |
+| Pagamento por dia / folha | Incompleta | Paridade | Campo `valor_dia` existe; sem tela |
+| EPI e segurança do trabalho | **Ausente** | Diferencial | — |
+
+### 2.1.6. Módulo Admin
+
+| Funcionalidade | Status | Tipo | Observação |
+|---|---|---|---|
+| Métricas globais (obras, usuários, documentos) | Completa | Paridade | Sem RBAC — bug de segurança |
+| Listagem de clientes (multi-tenancy) | Completa | Diferencial | Arquitetura madura |
+| Auditoria de profissionais | Completa | Diferencial | Status PENDENTE/VERIFICADO/INVALIDO |
+| Simulação de rentabilidade (SaaS mock) | Completa | Commodity | Mockado |
+| Impersonação de usuários | Completa | Diferencial | Com banner de aviso |
+| Health check | Completa | Commodity | — |
+
+### 2.1.7. Módulos planejados no schema mas NÃO implementados
+
+Estes modelos existem no Prisma sem controllers/rotas correspondentes — representam **~40% do schema ocioso**:
+
+| Modelo | Finalidade óbvia | Esforço p/ completar |
+|---|---|---|
+| `tb_material` | Catálogo global de materiais | M |
+| `tb_fabricante` | Catálogo de fabricantes | S |
+| `tb_material_fabricante` | M:N material × fabricante | S |
+| `tb_etapa` | Etapas/fases da obra | M |
+| `tb_etapa_material` | Materiais por etapa | M |
+| `tb_requisicao` | Requisição de material | M |
+| `tb_material_requisitado` | Itens da requisição | S |
+| `tb_estoque_obra` | ✅ implementado parcialmente | — |
+| `tb_movimentacao_estoque` | ✅ implementado parcialmente | — |
+
+**Conclusão:** O projeto tem 7 entidades prontas para virar um **módulo de Materiais, Etapas e Requisições** — alta alavancagem, baixo custo incremental (cerca de 3 semanas de trabalho para um dev), alto impacto de produto (aproxima-se de Sienge e Vobi).
+
+---
+
+## 2.2. Benchmark competitivo — mercado brasileiro
+
+Pesquisa feita em abril de 2026 cobrindo 4 concorrentes principais do segmento de software de gestão de obras para construção civil no Brasil. Fontes consultadas (nota: links ao final da seção).
+
+### 2.2.1. Sienge
+
+**Posicionamento:** líder para construtoras médias e grandes. Ecossistema completo (ERP da construção).
+
+**Funcionalidades-chave:**
+- Contratos com gerador automático em Word
+- Medições com fotos integradas
+- Relatórios previsto × realizado
+- Controle de materiais e fornecedores
+- Gestão financeira (contas a pagar/receber, fluxo de caixa, DRE)
+- Folha de pagamento
+- Integração contábil
+
+**Preço:** premium (mensalidade para 10+ usuários). Não atende pequenos empreiteiros por custo.
+
+**Gap que Obra Integrada pode explorar:** mercado de **construtoras de 1 a 10 obras/ano** e empreiteiros individuais — custo acessível + experiência mobile.
+
+### 2.2.2. Vobi
+
+**Posicionamento:** "O único software de gestão de obras com Agentes de IA do Brasil" (slogan oficial).
+
+**Funcionalidades-chave:**
+- Orçamento com integração SINAPI (tabela nacional de insumos da construção)
+- Controle financeiro e cronograma
+- Diário de obras
+- **Agentes de IA** (principal diferencial declarado)
+- Foco em construtoras pequenas/médias, empreiteiros, escritórios de arquitetura/design
+
+**Gap que Obra Integrada pode explorar:** Vobi ainda é SaaS proprietário; o Obra Integrada pode posicionar-se como **alternativa brasileira com foco mobile-first para canteiro** (campo, não escritório).
+
+### 2.2.3. Obra Prima
+
+**Posicionamento:** 2.000+ empresas, foco em pequenas e médias construtoras.
+
+**Funcionalidades-chave:**
+- Orçamentação rápida
+- Cronograma físico-financeiro integrado
+- **RDO (Relatório Diário de Obra) completo** — bem formatado, com fotos, para enviar ao cliente
+- Aplicativo mobile
+
+**Gap:** o Obra Integrada já tem diário de obra com foto + GPS — é necessário **formatar em RDO exportável** (PDF mensal) para empatar.
+
+### 2.2.4. Mobuss Construção
+
+**Posicionamento:** solução modular do canteiro ao pós-obra.
+
+**Funcionalidades-chave (11 módulos):**
+- Projetos
+- Apropriação (pointing — alocação de horas)
+- Diário de obra
+- Insumos
+- Documentos
+- Apontamentos
+- Segurança
+- Qualidade
+- Inspeção e Entrega
+- Assistência Técnica (pós-obra)
+- Integrações com ERPs, CRMs, catracas físicas
+
+**Gap:** a modularidade do Mobuss é inspiradora — o Obra Integrada pode seguir a mesma lógica de **ativação opcional de módulos** por cliente (ex: cliente X só quer Diário + Tarefas, não paga pelo resto).
+
+### 2.2.5. Consolidação de gaps do Obra Integrada vs. mercado
+
+Tabela comparativa (✓ = presente e funcional, ⚠ = parcial, ✗ = ausente):
+
+| Funcionalidade | Obra Integrada | Sienge | Vobi | Obra Prima | Mobuss |
+|---|---|---|---|---|---|
+| Cadastro de obras | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Diário de obra | ✓ | ✓ | ✓ | ✓ | ✓ |
+| Diário com GPS + auditoria geográfica | ✓ | ✗ | ✗ | ⚠ | ⚠ |
+| RDO exportável em PDF | ✗ | ✓ | ✓ | **✓ (principal)** | ✓ |
+| Orçamento com SINAPI | ✗ | ✓ | **✓ (diferencial)** | ✓ | ⚠ |
+| Cronograma físico-financeiro | ⚠ | ✓ | ✓ | ✓ | ✓ |
+| Gantt visual | ✗ | ✓ | ✓ | ✓ | ✓ |
+| Catálogo de materiais | ⚠ schema only | ✓ | ✓ | ✓ | ✓ |
+| Catálogo de fabricantes | ⚠ schema only | ✓ | ✓ | ⚠ | ✓ |
+| Requisição de material | ⚠ schema only | ✓ | ✓ | ✓ | ✓ |
+| Estoque por obra com movimentações | ✓ | ✓ | ✓ | ✓ | ✓ |
+| RH / folha / ponto | ⚠ parcial | ✓ | ⚠ | ✓ | ✓ |
+| Segurança do trabalho (EPI) | ✗ | ⚠ | ✗ | ✗ | **✓ (diferencial Mobuss)** |
+| Qualidade / inspeção | ✗ | ⚠ | ✗ | ⚠ | ✓ |
+| Financeiro — fluxo de caixa | ✗ | ✓ | ✓ | ✓ | ⚠ |
+| DRE / relatórios gerenciais | ✗ | ✓ | ✓ | ⚠ | ⚠ |
+| Agentes de IA | ✗ | ✗ | **✓ (único)** | ✗ | ✗ |
+| App mobile | ✗ | ✓ | ✓ | ✓ | ✓ |
+| PWA offline | ✗ | ✗ | ✗ | ⚠ | ⚠ |
+| Multi-tenancy | ✓ | ✓ | ✓ | ✓ | ✓ |
+| WhatsApp (notificações) | ✗ | ⚠ | ⚠ | ✓ | ⚠ |
+| Integração contábil | ✗ | ✓ | ⚠ | ⚠ | ⚠ |
+| Impersonação admin | ✓ | ⚠ | ⚠ | ⚠ | ⚠ |
+| Auditoria estrutural (log permanente) | ⚠ (quebrado) | ✓ | ✓ | ✓ | ✓ |
+
+**Sinais positivos:** O Obra Integrada já tem 3 itens onde se posiciona **igual ou melhor** que os líderes (diário com GPS, impersonação admin, multi-tenancy no core desde o início).
+
+**Sinais preocupantes:** Falta o básico do concorrente brasileiro mais popular em pequenas construtoras (RDO exportável do Obra Prima). Implementar isso é o gap #1 do roadmap.
+
+**Fontes consultadas:**
+- [Os 12 melhores softwares de gestão de obras — blog Obra Prima](https://blog.obraprima.eng.br/12-melhores-de-softwares-de-gestao-de-obras/)
+- [Os 10 Melhores Softwares para Construtoras em 2026 — Foco em Obra](https://focoenobra.com/pt-br/blog/10-melhores-softwares-para-construtoras/)
+- [Vobi — Software de Gestão de Obras com Agentes de IA](https://www.vobi.com.br)
+- [Sienge — Software de gestão de obras](https://sienge.com.br/blog/software-de-gestao-de-obras/)
+- [Mobuss Construção — solução modular](https://www.mobussconstrucao.com.br/)
+- [Mobuss — Diário de obras](https://www.mobussconstrucao.com.br/modulo/diario-de-obras/)
+
+---
+
+## 2.3. Novas funcionalidades sugeridas
+
+A seguir, **15 features propostas** com racional completo. A distribuição ao longo do cronograma de 24 meses está em 2.3.16.
+
+### 2.3.1. Feature 01 — RDO exportável em PDF
+
+**Problema que resolve:** o diário de obra existe, mas não há forma de **entregar ao cliente** (engenheiro/proprietário) um relatório formatado. Hoje cada entrada fica isolada no sistema.
+
+**Descrição funcional:** dado um intervalo de datas (dia, semana, mês), gerar PDF com logo da obra, cabeçalho (obra, cliente, engenheiro responsável), lista de entradas do diário no período (cada uma com descrição, foto reduzida, GPS, autor, status de auditoria) e resumo (dias trabalhados, dias parados, fotos totais). Botão "Enviar por e-mail ao cliente".
+
+**Tecnologia:** `pdfkit` ou `puppeteer-core` (renderizar HTML → PDF) no backend; template HTML/React SSR.
+
+**Impacto no usuário:** **5/5** — paridade com Obra Prima, diferencial versus Sienge em pequena escala.
+
+**Esforço de implementação:** **M** (3-5 dias).
+
+**Dependências técnicas:** migração de uploads para S3/Supabase (Feature 06), caso contrário fotos não aparecem no PDF em produção.
+
+**Mês sugerido:** Mês 4.
+
+### 2.3.2. Feature 02 — Módulo de Materiais + Catálogo de Fabricantes
+
+**Problema que resolve:** 7 entidades do schema (`tb_material`, `tb_fabricante`, `tb_material_fabricante`, `tb_etapa`, `tb_etapa_material`, `tb_requisicao`, `tb_material_requisitado`) estão prontas mas não expostas — potencial de mercado desperdiçado.
+
+**Descrição funcional:**
+- CRUD de materiais globais (cimento, brita, areia, tinta, etc.) com unidade de medida, preço unitário, densidade, resistência
+- CRUD de fabricantes
+- M:N entre material e fabricante (ex: cimento CP-II pode ser Votorantim, Mizu ou InterCement)
+- Filtro por material em requisições
+
+**Tecnologia:** 7 novos controllers + rotas + telas FE.
+
+**Impacto no usuário:** **4/5** — habilita orçamentação, requisições, estoque — bloqueador para Features 03 e 04.
+
+**Esforço:** **L** (~2 semanas).
+
+**Dependências:** nenhuma.
+
+**Mês sugerido:** Mês 5.
+
+### 2.3.3. Feature 03 — Módulo de Etapas da Obra (Cronograma Físico)
+
+**Problema que resolve:** obras têm etapas (fundação, estrutura, alvenaria, acabamento), mas hoje não existem como objetos — tarefas ficam soltas.
+
+**Descrição funcional:**
+- Cada obra tem N etapas com nome, `previsao_inicio`, `previsao_fim`, `id_status`
+- Cada etapa tem M materiais previstos (via `tb_etapa_material`)
+- Progresso da etapa = % de tarefas concluídas dentro dela
+- Visualização em timeline horizontal (similar a Gantt simplificado)
+
+**Tecnologia:** schema já existe. Backend: CRUD. Frontend: componente de timeline customizado (ou `dhtmlx-gantt` / `frappe-gantt`).
+
+**Impacto:** **5/5** — bloqueador para Feature 04 (caminho crítico) e Feature 07 (previsto × realizado).
+
+**Esforço:** **L** (~2 semanas).
+
+**Dependências:** Feature 02 parcial (só materiais).
+
+**Mês sugerido:** Mês 6.
+
+### 2.3.4. Feature 04 — Cronograma físico-financeiro com Curva S
+
+**Problema que resolve:** construtoras precisam visualizar **avanço físico** (% da obra entregue) × **avanço financeiro** (% do orçamento gasto) ao longo do tempo. É o KPI clássico da construção.
+
+**Descrição funcional:**
+- Gráfico de curva S com 3 linhas: previsto físico, realizado físico, realizado financeiro
+- Alerta automático quando realizado físico < previsto físico - 10%
+- Exportável
+
+**Tecnologia:** ApexCharts (já no stack) para gráfico; cálculos no backend.
+
+**Impacto:** **5/5** — paridade com concorrentes grandes; vende a banca acadêmica (visualização profissional).
+
+**Esforço:** **M** (4-6 dias).
+
+**Dependências:** Feature 03.
+
+**Mês sugerido:** Mês 7.
+
+### 2.3.5. Feature 05 — PWA offline-first para canteiro de obra
+
+**Problema que resolve:** canteiros de obra frequentemente têm **conexão 3G/4G instável ou ausente**. Hoje o frontend é SPA online — se o mestre de obras perde sinal, não registra o diário.
+
+**Descrição funcional:**
+- Service Worker com cache estratégico (CacheFirst para assets, NetworkFirst com fallback para dados)
+- Fila de sincronização: diário/tarefa criados offline ficam em IndexedDB e são enviados quando reconecta
+- Indicador visual "modo offline" na UI
+- Instalável como PWA (`manifest.json`, ícones)
+
+**Tecnologia:** `vite-plugin-pwa` + `workbox`. IndexedDB via `idb` ou `dexie`.
+
+**Impacto:** **5/5** — **diferencial enorme para canteiro**, nenhum concorrente grande faz bem.
+
+**Esforço:** **L** (~2 semanas).
+
+**Dependências:** Feature 06 (storage externo), caso contrário fotos offline não sincronizam.
+
+**Mês sugerido:** Mês 10.
+
+### 2.3.6. Feature 06 — Storage externo (Supabase Storage ou R2)
+
+**Problema que resolve:** `multer.diskStorage` é incompatível com Vercel (filesystem efêmero). Bloqueador de produção.
+
+**Descrição funcional:**
+- Backend: trocar `storageService.js` para upload direto ao Supabase Storage ou Cloudflare R2
+- Streaming direto (memoryStorage do multer + stream)
+- URL pré-assinada (signed URL) para download privado
+
+**Tecnologia:** `@supabase/storage-js` OU `@aws-sdk/client-s3` + R2 endpoint.
+
+**Impacto:** **5/5** — bloqueador.
+
+**Esforço:** **M** (3-5 dias).
+
+**Dependências:** nenhuma.
+
+**Mês sugerido:** Mês 2 (antes do primeiro deploy em Vercel).
+
+### 2.3.7. Feature 07 — IA: geração automática de RDO a partir de texto + fotos
+
+**Problema que resolve:** pedreiro/mestre não quer digitar um parágrafo bem escrito. Dita no WhatsApp ("Hoje concretou a laje do térreo, usamos 4 caminhões de brita, faltou cimento CP-II"). Virar isso em RDO formatado é trabalhoso.
+
+**Descrição funcional:**
+- Usuário manda mensagem de voz ou texto + fotos
+- IA (Claude/GPT-4) estrutura em: atividades realizadas, materiais usados, pendências, observações
+- Retorna JSON estruturado que é pré-preenchido no diário
+- Analisa fotos para detectar EPI (capacete, bota) e alertar
+
+**Tecnologia:** API Anthropic ou OpenAI; vision model para análise de foto.
+
+**Impacto:** **5/5** — diferencial IA competitivo com Vobi; banca acadêmica adora.
+
+**Esforço:** **L** (~3 semanas).
+
+**Dependências:** Features 01 e 06.
+
+**Mês sugerido:** Mês 13.
+
+### 2.3.8. Feature 08 — Estimativa automática de materiais por m² via IA + SINAPI
+
+**Problema que resolve:** orçamentação é trabalhosa; hoje o usuário calcula materiais manualmente.
+
+**Descrição funcional:**
+- Dado: área da obra (m²), tipo (casa térrea, sobrado, comercial), nível de acabamento (popular/médio/alto)
+- IA sugere lista de materiais com quantidades baseadas em tabelas SINAPI e padrões comuns
+- Usuário revisa, ajusta, confirma. Sistema cria requisições iniciais.
+
+**Tecnologia:** SINAPI via dataset público (atualização mensal); IA para interpretar input; regras para cálculo por m².
+
+**Impacto:** **5/5** — paridade com Vobi; vende o produto em demos.
+
+**Esforço:** **XL** (~1 mês).
+
+**Dependências:** Features 02 e 03.
+
+**Mês sugerido:** Mês 15.
+
+### 2.3.9. Feature 09 — Chat com IA para trabalhadores ("Dúvidas da obra")
+
+**Problema que resolve:** ajudante pergunta "quanto de cimento vai num saco de argamassa?" — sem treinamento é complicado.
+
+**Descrição funcional:**
+- Chatbot embarcado no app/PWA
+- RAG (Retrieval Augmented Generation) sobre base de conhecimento: manuais de fabricantes, normas ABNT, tabelas de traço de concreto
+- Usuário digita ou fala pergunta, IA responde com fontes
+- Memória curta por sessão
+
+**Tecnologia:** Claude/GPT + embedding + vector DB (Supabase pgvector é suficiente).
+
+**Impacto:** **4/5** — marketing forte, utilidade real limitada (pedreiros experientes já sabem).
+
+**Esforço:** **L** (~2 semanas).
+
+**Dependências:** nenhuma técnica, mas exige curadoria de conteúdo.
+
+**Mês sugerido:** Mês 17.
+
+### 2.3.10. Feature 10 — Notificações WhatsApp Business (ativas)
+
+**Problema que resolve:** trabalhador não abre app. Mas todo mundo usa WhatsApp.
+
+**Descrição funcional:**
+- Integração com WhatsApp Business Cloud API (Meta)
+- Triggers: tarefa atribuída, prazo vencendo em 24h, diário requer auditoria, pagamento próximo
+- Usuário pode responder "concluída" no WhatsApp e o sistema atualiza o status
+
+**Tecnologia:** WhatsApp Cloud API; webhook de mensagens recebidas; número verificado.
+
+**Impacto:** **4/5** — diferencial real no mercado BR.
+
+**Esforço:** **L** (~2 semanas) + processo burocrático de verificação Meta.
+
+**Dependências:** nenhuma técnica; dependência legal (conta verificada Meta).
+
+**Mês sugerido:** Mês 14.
+
+### 2.3.11. Feature 11 — Módulo de Segurança do Trabalho (EPI + NR-18)
+
+**Problema que resolve:** segurança em canteiro é obrigatória (NR-18); não tem no Obra Integrada. Mobuss usa como diferencial.
+
+**Descrição funcional:**
+- Checklist de EPI por trabalhador (capacete, botina, óculos, luva, cinto de segurança) — entrega registrada
+- Ficha de NR-18 por obra (condições do canteiro)
+- Registro de incidentes (leve, moderado, grave)
+- Dashboard com taxa de entrega de EPI, incidentes por mês
+
+**Tecnologia:** novas entidades Prisma + CRUD. Foto do trabalhador com EPI colocado (feature 07 pode auto-validar).
+
+**Impacto:** **4/5** — compliance legal, diferencial em concorrentes pequenos.
+
+**Esforço:** **L** (~2 semanas).
+
+**Dependências:** Feature 11 pode usar Feature 07 se integrado.
+
+**Mês sugerido:** Mês 18.
+
+### 2.3.12. Feature 12 — Dashboard executivo BI
+
+**Problema que resolve:** proprietário de construtora pequena quer saber "como está o negócio?" — hoje tem que abrir cada obra.
+
+**Descrição funcional:**
+- Widgets: número de obras ativas, faturamento no mês, margem média, obras atrasadas, tarefas pendentes, fluxo de caixa consolidado
+- Filtro por período
+- Exportação Excel/PDF
+- Drill-down por obra
+
+**Tecnologia:** ApexCharts já no stack.
+
+**Impacto:** **4/5** — vende para o tomador de decisão (proprietário).
+
+**Esforço:** **M** (~1 semana).
+
+**Dependências:** Features 03 e 04.
+
+**Mês sugerido:** Mês 8.
+
+### 2.3.13. Feature 13 — Integração com Google Maps (navegação)
+
+**Problema que resolve:** trabalhador recebe endereço da obra e precisa copiar-colar no maps. Poderia ser click-to-navigate.
+
+**Descrição funcional:**
+- Na tela da obra, botão "Ir até a obra" que abre Google Maps com rota
+- Se feature 05 (PWA), usa geolocalização atual como origem
+- Ícone no app para última obra visitada
+
+**Tecnologia:** deep link `https://www.google.com/maps/dir/?api=1&destination=LAT,LONG`. Sem custo de API.
+
+**Impacto:** **3/5** — conveniência, não transformador.
+
+**Esforço:** **S** (<1 dia).
+
+**Dependências:** nenhuma. Já tem lat/long na obra.
+
+**Mês sugerido:** Mês 3 (quick win).
+
+### 2.3.14. Feature 14 — Previsão do tempo por obra
+
+**Problema que resolve:** `operationalController.getWeatherMock` é placeholder. Concretagem não pode em chuva; mestre de obras precisa saber com antecedência.
+
+**Descrição funcional:**
+- Para cada obra (lat/long), busca previsão de 7 dias em API pública (OpenWeatherMap, CPTEC, INPE)
+- Alerta na dashboard se previsão de chuva >60% em dia de concretagem planejada
+- Integração com tarefas: marcar tarefa como "sensível a chuva"
+
+**Tecnologia:** OpenWeatherMap tem plano free (1000 calls/dia — suficiente para <30 obras ativas).
+
+**Impacto:** **4/5** — utilidade real, fácil de demonstrar.
+
+**Esforço:** **S** (~2 dias).
+
+**Dependências:** nenhuma.
+
+**Mês sugerido:** Mês 3 (quick win).
+
+### 2.3.15. Feature 15 — Biblioteca de plantas e BIM (visualização básica)
+
+**Problema que resolve:** upload de documentos existe, mas PDF de planta fica misturado com contratos e NFs. Engenheiro quer visualização rápida no mobile.
+
+**Descrição funcional:**
+- Categorização de documentos: Planta, Contrato, NF, Foto, ART/RRT, Licença
+- Viewer embutido de PDF/DWG (visualização leve)
+- Anotações do engenheiro na planta (pontos com comentário)
+- Links de planta compartilháveis com trabalhador (sem login)
+
+**Tecnologia:** `react-pdf` para PDF; `three.js` + `three-dxf` para DWG (mais complexo).
+
+**Impacto:** **4/5** — diferencial profissional.
+
+**Esforço:** **L** (~2 semanas).
+
+**Dependências:** Feature 06.
+
+**Mês sugerido:** Mês 20.
+
+### 2.3.16. Cronograma macro das 15 features
+
+| Mês | Feature | Esforço | Justificativa de posicionamento |
+|---|---|---|---|
+| 2 | Feature 06 — Storage S3/Supabase | M | Bloqueador de deploy |
+| 3 | Feature 13 — Google Maps | S | Quick win (<1 dia) |
+| 3 | Feature 14 — Previsão do tempo | S | Quick win, substitui o mock atual |
+| 4 | Feature 01 — RDO PDF | M | Fecha gap competitivo com Obra Prima |
+| 5 | Feature 02 — Materiais + Fabricantes | L | Base para toda cadeia de orçamento |
+| 6 | Feature 03 — Etapas | L | Base para cronograma e BI |
+| 7 | Feature 04 — Curva S | M | Visual profissional para banca |
+| 8 | Feature 12 — Dashboard BI | M | Consolida dados das anteriores |
+| 10 | Feature 05 — PWA offline | L | Diferencial mobile; após base estável |
+| 13 | Feature 07 — IA de RDO | L | Requer base Features 01 e 06 |
+| 14 | Feature 10 — WhatsApp | L | Requer verificação Meta (processo longo) |
+| 15 | Feature 08 — IA + SINAPI | XL | Maior complexidade, após materiais |
+| 17 | Feature 09 — Chat IA trabalhadores | L | Refinamento; base de conhecimento leva tempo |
+| 18 | Feature 11 — Segurança do trabalho | L | Módulo grande, mas sem bloqueadores |
+| 20 | Feature 15 — Biblioteca de plantas/BIM | L | Polimento final |
+
+**Total de esforço:** ~6 meses-equivalente de 1 desenvolvedor (considerando 5 devs trabalhando em paralelo + overhead, cabe confortavelmente em 18 meses dedicados a features + 2 meses de polimento).
+
+---
+
+## 2.4. Oportunidades de arquitetura
+
+### 2.4.1. Eventos e filas assíncronas
+
+**Caso de uso:**
+- Envio de e-mail de auditoria pendente
+- Processamento de foto do diário (redimensionamento, geração de thumbnail, análise de EPI via IA)
+- Geração de PDF RDO mensal
+- Notificação WhatsApp
+- Sync offline (Feature 05)
+
+**Alternativas:**
+- **BullMQ + Redis (Upstash)**: padrão Node.js, integra bem, Upstash tem free tier serverless
+- **AWS SQS + Lambda**: mais escalável, mas complexidade operacional maior
+- **Inngest**: função-como-job, integra direto com Vercel, produto jovem mas crescente
+
+**Recomendação:** BullMQ + Upstash para MVP (entrega valor em Mês 4), reavaliar para Inngest quando processamentos chegarem a milhares/dia.
+
+### 2.4.2. Cache
+
+**Caso de uso:**
+- `requireObraAccess` executa 2-3 queries por request protegido — cachear o mapa `user → obras acessíveis` por 60s reduz carga significativamente
+- Catálogos (`tb_status`, `tb_papel`, materiais globais) — cacheáveis por horas
+- Métricas globais do Admin — recalcular a cada 5 min, servir cached
+
+**Alternativas:**
+- **Redis (Upstash)**: mesma infra do BullMQ
+- **In-memory LRU com invalidação por TTL**: suficiente por Vercel Function; trade-off: cada instância tem seu cache (pior para dados compartilhados)
+- **Vercel Edge Config**: ótimo para dados globais raramente mutáveis
+
+**Recomendação:** Upstash Redis compartilhado para o que é compartilhável; LRU em memória para o resto.
+
+### 2.4.3. Realtime
+
+**Caso de uso:**
+- Quando mestre de obras adiciona entrada no diário, gerente vê na dashboard sem refresh
+- Colaboração em formulário de obra (2 pessoas editando a mesma obra)
+- Notificação visual em tempo real
+
+**Alternativas:**
+- **Supabase Realtime** (CDC do Postgres via WebSocket): se DB já é Supabase, é zero-effort
+- **Pusher** / **Ably**: SaaS dedicados, free tiers generosos
+- **Server-Sent Events (SSE)** caseiro: simples, funciona em Vercel com streaming (Edge Functions)
+
+**Recomendação:** Supabase Realtime se o Postgres estiver hospedado lá (ADR-002). Custo zero, setup de 1 hora.
+
+### 2.4.4. Integrações externas
+
+| Integração | Prioridade | Mês | Complexidade |
+|---|---|---|---|
+| WhatsApp Business (Meta Cloud API) | Alta | 14 | Alta (burocrática) |
+| Google Maps / Geocoding | Média | 3 | Baixa |
+| OpenWeatherMap / CPTEC | Média | 3 | Baixa |
+| SINAPI (dados públicos Caixa) | Alta | 15 | Média (parse de planilha) |
+| WhatsApp Twilio (alternativa) | Baixa | 18 | Baixa (custo por mensagem) |
+| API de cotação de materiais | Baixa | 22 | Média (sem API oficial; scraping de Leroy / C&C) |
+| IA (Anthropic / OpenAI) | Alta | 13 | Baixa |
+| Stripe / Pagar.me | Média | 20 | Média (para SaaS cobrar assinatura) |
+| ReceitaWS / CPF validation | Baixa | 12 | Baixa |
+| Cloudinary (fallback de imagens) | Baixa | — | Baixa |
+
+### 2.4.5. Arquitetura em camadas (preparação para escala)
+
+Proposta detalhada no artefato 03 (ADR-011 implícito). Em resumo:
+
+```
+┌──────────────────────────────────┐
+│  Controllers (HTTP adapters)     │
+├──────────────────────────────────┤
+│  Services (regra de negócio)     │
+├──────────────────────────────────┤
+│  Repositories (acesso a dados)   │
+├──────────────────────────────────┤
+│  Prisma / External APIs          │
+└──────────────────────────────────┘
+```
+
+Aplicar **Ports & Adapters (Hexagonal Architecture)** de Alistair Cockburn, com as seguintes correspondências:
+- **Ports:** interfaces de service (ex: `IObraService.criar(dto)`)
+- **Adapters primários:** controllers Express (recebem HTTP e chamam service)
+- **Adapters secundários:** `PrismaObraRepository`, `SupabaseStorageAdapter`, `WhatsAppNotifier`
+
+Isso permite trocar Prisma → Drizzle, ou Supabase → R2, sem tocar em services. Critério para aplicar: módulos novos (Features 02, 03) já nascem com a arquitetura correta; módulos existentes são refatorados gradualmente.
+
+---
+
+## Conclusão da Fase 2
+
+O Obra Integrada está em **posição estratégica favorável** como projeto acadêmico: escopo já funcional, arquitetura moderna, e 7 entidades de materiais/requisições prontas para virar módulo — uma vantagem de **~3 semanas de trabalho** sobre um começo do zero.
+
+As 15 features propostas equilibram: (1) **paridade competitiva** (RDO PDF, cronograma físico-financeiro, materiais) nas Features 01-04, 12; (2) **diferencial mobile-first** (PWA, Google Maps, tempo) nas Features 05, 13, 14; (3) **diferencial IA para impressionar banca** (RDO automático, estimativa SINAPI, chat) nas Features 07, 08, 09; e (4) **lock-in e compliance** (EPI/NR-18, BI, biblioteca de plantas) nas Features 11, 12, 15.
+
+Nenhuma feature isolada é revolucionária — o diferencial do produto acadêmico é **a combinação coerente** de mobile-first + GPS nativo + IA aplicada + modularidade por cliente, colocando o Obra Integrada em posição competitiva com Vobi (diferencial IA) e Obra Prima (RDO e simplicidade) para a faixa de construtoras pequenas.
+
+O detalhamento de **como** implementar essas features com qualidade (arquitetura, ADRs, limpeza técnica) está no artefato 03.

--- a/docs/docs/auditoria-inicial/03-plano-refatoracao.md
+++ b/docs/docs/auditoria-inicial/03-plano-refatoracao.md
@@ -1,0 +1,543 @@
+# Fase 3 — Plano de Refatoração e Modernização
+
+**Projeto:** Obra Integrada
+**Data:** 24 de abril de 2026
+**Escopo:** Decisões arquiteturais (ADRs), plano de limpeza imediata e roadmap de refatoração incremental (Meses 1-6)
+
+---
+
+## Sumário executivo
+
+Este artefato consolida **10 Architecture Decision Records (ADRs)** no formato de Michael Nygard (*Documenting Architecture Decisions*, 2011), um **plano de limpeza de 2 semanas** para remover débito óbvio, e um **roadmap de 6 meses** de PRs sequenciais em ordem de dependência.
+
+As decisões arquiteturais são apresentadas como **recomendações fundamentadas** — não imposições. Cada ADR lista o problema, pelo menos 2 opções com prós/contras, e a recomendação. O time é livre para discordar em Review, documentando a divergência como ADR-XXX-accepted/superseded.
+
+O plano de refatoração segue o princípio **Strangler Fig Pattern** (Martin Fowler, 2004): em vez de *big-bang rewrite*, refatorações convivem com o código legado; PRs pequenos, reversíveis, com testes que preservam comportamento.
+
+---
+
+## 3.1. Decisões arquiteturais (ADRs propostos)
+
+### ADR-001 — Manter JavaScript ou migrar para TypeScript?
+
+**Status:** Proposto
+**Contexto:** O backend é 100% JavaScript ESM. O frontend mistura `.jsx` e `.tsx` (15 arquivos TS de 80+). O linter do frontend ignora `.tsx` (`--ext js,jsx`). O projeto tem 24 meses para crescer de ~15 mil para estimados 50 mil linhas.
+
+#### Opções
+
+**Opção A — Manter JavaScript em ambos**
+- Prós: zero custo de migração; equipe não precisa aprender TS; build mais simples
+- Contras: sem tipos em domínio crítico (ex: `tb_obra` tem 28 campos; erro de digitação é `undefined` em runtime); refactors grandes são arriscados; IDE oferece menos ajuda; onboarding é mais lento
+
+**Opção B — TypeScript no backend + completar TS no frontend**
+- Prós: integração natural com Prisma (já gera tipos); refactors seguros; IDE poderosa; contratos de API compartilháveis (monorepo); atrai desenvolvedores (mercado demanda TS)
+- Contras: curva de aprendizado inicial (~2 semanas para dev sem exposição); build mais lento (~30%); complexidade de tsconfig; exige disciplina
+
+**Opção C — TypeScript só em código novo (strangler)**
+- Prós: migração incremental; time aprende gradualmente; código existente continua funcionando
+- Contras: dois padrões coexistindo por muito tempo; `any` fácil em fronteiras; linter precisa de duas regras
+
+#### Recomendação
+
+**Opção C com meta de migração para Opção B em 12 meses.** Todo código novo (controllers, services, componentes) a partir do Mês 3 deve ser TypeScript. Refatoração de código legado acontece oportunisticamente (quando uma função já será tocada, migra-se o arquivo inteiro). Meta ao fim do Mês 12: >70% dos arquivos `.ts`/`.tsx`.
+
+**Fundamentação:** Reduz risco de big-bang rewrite. Princípio *Make the change easy, then make the easy change* (Kent Beck).
+
+---
+
+### ADR-002 — Storage de uploads (Supabase Storage × Cloudflare R2 × AWS S3)
+
+**Status:** Proposto
+**Contexto:** `multer.diskStorage` é incompatível com Vercel. Diário, documentos e comprovantes financeiros dependem de storage persistente. Decisão afeta Features 01, 05, 06, 07, 15 do artefato 02.
+
+#### Opções
+
+**Opção A — Supabase Storage**
+- Prós: integra com Postgres da Supabase (se adotado); free tier 1 GB; RLS (Row Level Security) por usuário; SDK maduro; região sa-east-1
+- Contras: atrela projeto ao Supabase; custo cresce com egress; menor ecosistema vs AWS
+
+**Opção B — Cloudflare R2**
+- Prós: S3-compatível; **egress grátis** (diferencial enorme); barato (US$0.015/GB/mês); ecosistema Cloudflare
+- Contras: sem região BR (us-east/eu-west); SDK menos maduro; signed URLs menos flexíveis
+
+**Opção C — AWS S3**
+- Prós: padrão da indústria; ecosistema amplo; região sa-east-1
+- Contras: custo de egress considerável; setup IAM mais complexo; overkill para projeto acadêmico
+
+#### Recomendação
+
+**Opção A — Supabase Storage**, com interface `IStorageAdapter` em `storageService.js` que permita trocar para R2 em 2-3 dias de trabalho se for necessário. A adoção do Supabase como Postgres (ADR-010 implícito) se alinha com essa escolha.
+
+**Fundamentação:** *Last responsible moment* (Lean Software Development). Começar simples, trocar quando o problema real aparecer. Abstração fina torna a troca possível sem reescrever todo o código.
+
+---
+
+### ADR-003 — Validação de schema (Zod × Joi × Yup × Valibot)
+
+**Status:** Proposto
+**Contexto:** Validação hoje é manual com regex dispersa. Vazam erros 500 para o usuário. Toda rota de input precisa de validação declarativa.
+
+#### Opções
+
+**Opção A — Zod**
+- Prós: integração TypeScript nativa (tipo inferido); API ergonomica; ecosistema (tRPC, react-hook-form resolver); tamanho razoável (~60 KB min+gzip)
+- Contras: um pouco mais lento que Joi em benchmarks sintéticos; sem i18n nativo
+
+**Opção B — Joi**
+- Prós: maduro; rico em features; suporte i18n; usado pelo Hapi
+- Contras: sem tipos TS bons; API mais verbosa; não "nasceu" TS
+
+**Opção C — Yup**
+- Prós: familiaridade no mundo react-hook-form; sintaxe clean
+- Contras: menor ecosistema hoje em 2026; tipos TS menos precisos que Zod
+
+**Opção D — Valibot**
+- Prós: **menor tamanho** (~2 KB tree-shakeable); API funcional moderna; muito rápido
+- Contras: jovem (2024); menor ecosistema; menos material didático
+
+#### Recomendação
+
+**Opção A — Zod.** Padrão de fato em 2026 para stacks TypeScript. Integra com react-hook-form (frontend) e com `@anatine/zod-openapi` para gerar OpenAPI do backend. Compartilhável entre FE e BE em monorepo.
+
+Exemplo de uso esperado:
+
+```typescript
+// schemas/obra.schema.ts
+import { z } from 'zod';
+export const CriarObraSchema = z.object({
+  nome: z.string().min(3).max(255),
+  tipo_obra: z.enum(['residencial', 'comercial', 'industrial']).optional(),
+  latitude: z.number().min(-90).max(90).optional(),
+  valor_orcado: z.number().positive().optional(),
+});
+export type CriarObraInput = z.infer<typeof CriarObraSchema>;
+
+// middleware validate()
+export const validate = (schema) => (req, res, next) => {
+  const result = schema.safeParse(req.body);
+  if (!result.success) return res.status(400).json({ error: 'VALIDATION', issues: result.error.issues });
+  req.body = result.data;
+  next();
+};
+```
+
+**Fundamentação:** Single Source of Truth (SSoT) — schema vira tipo TS e validador runtime simultaneamente.
+
+---
+
+### ADR-004 — Estratégia de testes (unitário × integração × E2E, meta de cobertura)
+
+**Status:** Proposto
+**Contexto:** Testes atuais são mocks; cobertura efetiva é <5%. Definir pirâmide, tooling, meta.
+
+#### Opções
+
+**Opção A — Pirâmide clássica (Mike Cohn)**: 70% unit, 20% integração, 10% E2E
+- Prós: padrão maduro; rápido em CI; isolamento bom
+- Contras: unit tests com mocks não capturam problemas de integração com Prisma; demanda disciplina
+
+**Opção B — Testing Trophy (Kent C. Dodds)**: 10% static (linter, TS), 20% unit, 50% integração, 20% E2E
+- Prós: confiança maior; integração é onde a maioria dos bugs vive; TS + ESLint são "grátis"
+- Contras: testes de integração são mais lentos; exige fixtures/seeds consistentes
+
+**Opção C — Pragmático: cobertura alta onde importa, baixa onde não importa**
+- Prós: foco em ROI; não persegue métricas vazias
+- Contras: subjetivo; difícil de auditar em PR review
+
+#### Recomendação
+
+**Opção B — Testing Trophy**, adaptada:
+
+| Tipo | Ferramenta | Cobertura esperada | Roda em |
+|---|---|---|---|
+| Static (TS strict, ESLint) | `tsc --noEmit`, `eslint` | 100% | Pre-commit + CI |
+| Unit (funções puras, services) | Vitest | ≥70% das services | CI a cada PR |
+| Integração API (com Postgres de teste) | Vitest + supertest + testcontainers | ≥60% das rotas | CI a cada PR (pode rodar paralelo) |
+| E2E (fluxos críticos) | Playwright | 5 fluxos: login, criar obra, registrar diário com foto, criar tarefa, upload financeiro | CI noturno + pré-merge em `main` |
+
+**Meta ao fim do Mês 6:** cobertura total ≥60% por linhas e ≥80% para módulos críticos (auth, obra, diário).
+
+**Remoção dos testes-mock atuais:** deletar ou reescrever `api.test.js` e `rh.test.js` na Semana 1.
+
+**Fundamentação:** Testing Trophy é o modelo moderno para apps que integram com banco e APIs externas. Cohn Pyramid foi escrita em 2009; web moderna é diferente.
+
+---
+
+### ADR-005 — Gerenciamento de estado no frontend
+
+**Status:** Proposto
+**Contexto:** Frontend usa React Context (Auth, Theme, Sidebar) + fetch manual. Não há cache, refetch, retry. Cada página trata 401 individualmente. Não usa TanStack Query, Zustand, Redux.
+
+#### Opções
+
+**Opção A — TanStack Query + Context para sessão**
+- Prós: cache automático; stale-while-revalidate; retry; devtools; integra com fetch/axios existente; separação clara: *server state* (TanStack Query) vs *client state* (Context)
+- Contras: conceito de queryKey exige disciplina; bundle ~13 KB gzipped
+
+**Opção B — Zustand + fetch manual**
+- Prós: leve (~3 KB); API simples; substitui múltiplos Contexts
+- Contras: não resolve problema de cache/retry; força o time a implementar manualmente
+
+**Opção C — Redux Toolkit + RTK Query**
+- Prós: maduro; padrão corporativo; Redux DevTools famosas
+- Contras: boilerplate maior; overkill para escala atual; learning curve
+
+**Opção D — Manter Context + interceptor centralizado**
+- Prós: zero nova dependência; foca no problema real (interceptor)
+- Contras: não resolve cache; refetch manual continua
+
+#### Recomendação
+
+**Opção A — TanStack Query** para todo server state (obras, tarefas, diário, usuários). **Context permanece para Auth, Theme, Sidebar.** Adicionalmente, criar um `apiClient` com interceptor de 401 que dispara logout e redireciona.
+
+**Fundamentação:** Separar *server state* de *client state* é o consenso de arquitetura frontend moderna (ver Dan Abramov, "*Before You Memo*" e Kent C. Dodds, "*Application State Management*"). Cache automático elimina dezenas de bugs de stale data.
+
+Implementação sugerida (após ADR-001 em TS):
+
+```typescript
+// hooks/useObra.ts
+export const useObra = (id: number) => useQuery({
+  queryKey: ['obra', id],
+  queryFn: () => apiClient.get(`/api/obras/${id}`),
+  staleTime: 1000 * 30, // 30s
+});
+```
+
+---
+
+### ADR-006 — Component library
+
+**Status:** Proposto
+**Contexto:** Frontend usa Tailwind 4 + componentes customizados. Não há design system externo. Há duplicações (`Header.tsx`, `ThemeToggleButton.tsx` vs `ThemeTogglerTwo.tsx`).
+
+#### Opções
+
+**Opção A — shadcn/ui**
+- Prós: **não é lib, são componentes copiados para o repo** — total controle; usa Radix primitives (acessibilidade OOTB); Tailwind-nativo; padrão em 2026 para stacks React modernas; dark mode funcional out-of-the-box
+- Contras: exige copiar componentes (CLI `npx shadcn add`); não recebe updates automáticos (é intencional)
+
+**Opção B — Mantine**
+- Prós: rico em componentes (150+); ótima documentação; hooks úteis; suporte nativo a dark mode
+- Contras: CSS-in-JS próprio (não Tailwind); pesado (~300 KB); travado em decisões visuais
+
+**Opção C — Chakra UI v3**
+- Prós: documentação exemplar; componentes acessíveis; sistema de temas flexível
+- Contras: v3 reestruturou API (migração de apps em v2 é custosa); Emotion runtime; peso ~250 KB
+
+**Opção D — Construir tudo do zero**
+- Prós: zero dependência
+- Contras: custo alto de implementar acessibilidade correta (WAI-ARIA, foco, teclado); reinventa roda
+
+#### Recomendação
+
+**Opção A — shadcn/ui**. É a escolha que melhor se alinha ao stack existente (Tailwind 4) e não acrescenta runtime significativo. Cada componente que for adicionado entra em `components/ui/` e pode ser customizado livremente.
+
+Primeiros componentes a migrar/adicionar: `Button`, `Input`, `Dialog`, `Toast` (substituir react-hot-toast), `DropdownMenu`, `Tabs`, `Table`, `Form` (integra com react-hook-form).
+
+**Fundamentação:** Ownership + acessibilidade + Tailwind-nativo. Todas as 3 opções alternativas tem 2-3 anos de maturidade a menos em 2026.
+
+---
+
+### ADR-007 — Estrutura de monorepo
+
+**Status:** Proposto
+**Contexto:** Hoje é um "monorepo de fato" sem ferramenta — `package.json` raiz orquestra via concurrently, mas com deps duplicadas. Há apenas 2 apps (backend, frontend); pode chegar a 3-4 (mobile, admin, landing).
+
+#### Opções
+
+**Opção A — Manter estrutura atual sem ferramenta**
+- Prós: zero complexidade
+- Contras: dev experience ruim; deps duplicadas; builds independentes
+
+**Opção B — npm workspaces**
+- Prós: **zero dependência nova** (built-in no npm 7+); simples; `npm install` da raiz instala tudo; `package.json` por app
+- Contras: sem cache de tarefas; sem pipeline de builds paralelos sofisticados
+
+**Opção C — pnpm workspaces**
+- Prós: mais rápido (~30%); usa menos disco (store global); suporte nativo a workspaces; compatível com npm
+- Contras: troca de package manager (exige alinhamento do time e de CI/CD)
+
+**Opção D — Turborepo**
+- Prós: cache distribuído; pipeline inteligente (só builda o que mudou); integra com Vercel
+- Contras: exige `turbo.json` + disciplina; overkill abaixo de 5 apps
+
+#### Recomendação
+
+**Opção B — npm workspaces**, com possibilidade de adicionar Turborepo no Mês 12+ quando houver 4+ pacotes. Mudança para pnpm é opcional e pode ser considerada mais tarde se builds estiverem lentos.
+
+Estrutura proposta:
+
+```
+obra-integrada/
+├── package.json              # root workspace
+├── package-lock.json         # único lock
+├── apps/
+│   ├── api/                  # ← backend (renomeado)
+│   └── web/                  # ← frontend/vite-project (renomeado)
+├── packages/
+│   └── shared-schemas/       # schemas Zod + tipos compartilhados FE↔BE
+```
+
+**Fundamentação:** Evitar complexidade prematura. npm workspaces atende o caso por 12+ meses.
+
+---
+
+### ADR-008 — Observabilidade
+
+**Status:** Proposto
+**Contexto:** Hoje logs vão para console da Vercel, sem contexto; sem alertas; sem APM.
+
+#### Opções
+
+**Opção A — Sentry**
+- Prós: líder em error tracking frontend + backend; free tier 5k errors/mês; source maps; breadcrumbs; alertas Slack
+- Contras: foca em erros, não em performance/traces completos
+
+**Opção B — Axiom**
+- Prós: log aggregation moderno; SQL sobre logs; integrado com Vercel (plugin oficial); free tier generoso
+- Contras: menos maduro em error tracking
+
+**Opção C — BetterStack (Logtail + Uptime)**
+- Prós: combina logs + uptime + status page; preço competitivo
+- Contras: menos recursos que Sentry em error tracking
+
+**Opção D — Datadog**
+- Prós: APM completo (traces, métricas, logs, RUM)
+- Contras: preço alto (não cabe em projeto acadêmico); setup pesado
+
+#### Recomendação
+
+**Combinação Opção A + Opção B: Sentry para erros + Axiom para logs estruturados.** Ambos tem integrações 1-click com Vercel. Free tiers cobrem o projeto por toda duração.
+
+Configuração esperada:
+- Frontend: `@sentry/react` com source maps no build
+- Backend: `@sentry/node` + integração Express
+- Pino logger exportando para Axiom
+
+**Fundamentação:** Observabilidade é o item mais subestimado no custo de manutenção. Ter Sentry desde cedo evita debugar problemas cegamente.
+
+---
+
+### ADR-009 — CI/CD (GitHub Actions)
+
+**Status:** Proposto
+**Contexto:** Sem CI hoje. Workflows necessários detalhados no artefato 04.
+
+#### Opções
+
+**Opção A — GitHub Actions**
+- Prós: grátis para repos públicos (2000 min/mês para privados); ecosistema enorme de actions; integra nativamente com GitHub
+- Contras: vendor lock-in
+
+**Opção B — CircleCI / GitLab CI**
+- Prós: alternativas maduras
+- Contras: exige configurar hosting; não agrega valor sobre Actions para este projeto
+
+#### Recomendação
+
+**Opção A — GitHub Actions**. Sem discussão — é o padrão para projetos hospedados no GitHub.
+
+Workflows mínimos (conteúdo completo no artefato 04):
+1. **ci.yml** — a cada PR: lint + TS check + unit + integração
+2. **preview-comment.yml** — postar URL da preview Vercel no PR
+3. **prisma-check.yml** — bloquear merge se há migration não aplicada
+
+Workflows para fases posteriores (Mês 3+):
+4. **e2e.yml** — noturno com Playwright contra staging
+5. **security.yml** — npm audit + Dependabot
+
+---
+
+### ADR-010 — Ambientes (dev / staging / produção)
+
+**Status:** Proposto
+**Contexto:** Hoje há apenas `dev` local + deploys na Vercel (preview + produção). Sem staging separado. Banco é o mesmo para todos os devs.
+
+#### Opções
+
+**Opção A — Mono-ambiente (apenas prod)**
+- Prós: simples
+- Contras: devs testam em produção; risco inaceitável para dados reais
+
+**Opção B — Dev local + Preview Vercel + Produção**
+- Prós: grátis; cada PR tem preview isolado
+- Contras: previews compartilham banco com produção por default; confusão de dados
+
+**Opção C — Dev + Staging + Produção com bancos separados**
+- Prós: segurança de dados; permite migrations em staging antes de prod
+- Contras: exige 2-3 bancos hospedados; complexidade de config
+
+#### Recomendação
+
+**Opção C** com configuração:
+
+| Ambiente | Vercel | Postgres | Branch |
+|---|---|---|---|
+| Dev | Local (vite + nodemon) | Local Docker ou Neon branch | qualquer |
+| Preview | Automático por PR | Neon branch descartável ou Supabase branch | `feature/*`, `fix/*` |
+| Staging | `staging.obra-integrada.vercel.app` | DB dedicado | branch `develop` |
+| Produção | `obra-integrada.vercel.app` | DB produção | branch `main` |
+
+**Postgres managed providers com "branching":**
+- **Neon** ⭐ — primeiro Postgres com branching instantâneo (como Git); cada PR pode ter banco isolado
+- **Supabase** — dá branching em beta; combina com ADR-002
+- **Railway** — simples, mas sem branching nativo
+
+**Recomendação combinada:** **Neon** para Postgres (diferencial: branching permite preview de PR com banco próprio, sem interferir em staging). Se Supabase for adotado por Storage (ADR-002), pode-se usar também por Postgres para simplificar — trade-off entre menos providers vs features de branching.
+
+**Fundamentação:** 12-Factor App, fator X — "Dev/prod parity"; ambientes devem ser o mais parecidos possível.
+
+---
+
+## 3.2. Plano de limpeza imediata (Semanas 1-2)
+
+Antes de qualquer nova funcionalidade, o repositório deve passar por higiene. Cada item é um PR pequeno (<200 linhas alteradas) em sequência. Tempo total estimado: **2 devs × 1 semana** (ou 1 dev × 2 semanas).
+
+### 3.2.1. Semana 1 — Crítico e bloqueadores
+
+| # | PR | Alvo | Ação | Risco | Verificação |
+|---|---|---|---|---|---|
+| 1 | `chore: remove orphaned server.js and legacy files` | `server.js` (raiz), `backend/src/database/{obras,users}.json`, `backend/standalone_users_server.js`, `backend/strip_maps.js`, `backend/check_db.mjs` | `git rm` | Baixo — nenhum é importado | `grep -r "server.js" --include='*.js'` não mostra imports |
+| 2 | `chore: remove orphaned seed scripts` | `backend/seed_*.mjs` (5 arquivos), `backend/seed_out.txt`, `backend/src/seed.js` duplicado | `git rm`; manter apenas `backend/src/prisma/seed.js` | Baixo | `npm run seed` ainda funciona |
+| 3 | `chore: remove legacy schema and dev.db` | `backend/src/prisma/schema.prisma.postgres`, `backend/src/prisma/dev.db` | `git rm --cached dev.db` + add ao `.gitignore` | Baixo | `npx prisma validate` passa |
+| 4 | `chore: consolidate .gitignore` | `.gitignore` raiz, `backend/.gitignore`, `backend/src/.gitignore` | Unificar em raiz: `node_modules`, `.env*`, `.vite/`, `coverage/`, `dev.db`, `uploads/*` (com exceção), `dist/`, `build/` | Baixo | `git status` mostra estado esperado |
+| 5 | `chore: add .vercelignore` | Novo arquivo `/vercelignore` | `node_modules`, `.env*`, `dev.db`, `coverage/`, `docs/`, `*.md` (exceto README), `backend/uploads/`, `.vite/` | Baixo | Simular deploy em conta Vercel; ver manifest |
+| 6 | `chore: add .env.example` | `apps/api/.env.example`, `apps/web/.env.example` | Documentar todas as vars identificadas na Seção 1.5.4 | Baixo | Revisão humana |
+| 7 | `fix(security): require JWT_SECRET env var` | `backend/src/middlewares/authMiddleware.js`, `backend/src/controllers/userController.js` | Remover fallback `"SUPER_SECRET"`; startup fails-fast se var ausente | **Médio** — requer adicionar var em todos ambientes antes | Testes de login em cada ambiente |
+| 8 | `fix(security): restrict CORS to FRONTEND_URL` | `backend/src/server.js` | `cors({ origin: process.env.FRONTEND_URL, credentials: true })` | Médio — pode quebrar localhost | Adicionar `http://localhost:*` em dev |
+| 9 | `fix(security): add requireRole to admin metrics` | `backend/src/routes/adminRoutes.js:20` | Adicionar `requireRole('ADMIN_MASTER', 'ADMIN')` | Baixo | Teste: user comum recebe 403 |
+| 10 | `fix(security): add requireObraAccess to DELETE financeiro` | `backend/src/routes/financeiroRoutes.js:43` | Adicionar middleware | Baixo | Teste: user sem acesso recebe 403 |
+
+### 3.2.2. Semana 2 — Reestruturação leve e higiene frontend
+
+| # | PR | Alvo | Ação | Risco |
+|---|---|---|---|---|
+| 11 | `chore(monorepo): restructure to apps/api and apps/web` | Rename `backend/` → `apps/api/`, `frontend/vite-project/` → `apps/web/` | `git mv` + atualizar scripts raiz + Vercel root directories | Médio — exige atualizar config Vercel dos 2 projetos antes do merge |
+| 12 | `chore: enable npm workspaces in root package.json` | `package.json` raiz | Adicionar `"workspaces": ["apps/*", "packages/*"]`; remover deps duplicadas da raiz | Médio — quebra `npm start` legacy |
+| 13 | `chore: remove frontend dead code (controllers, models)` | `apps/web/src/controllers/ObraController.js`, `apps/web/src/models/ObraModel.js` | `git rm` | Baixo — sem uso |
+| 14 | `chore: add banner.png to public or delete` | Raiz | Mover para `apps/web/public/banner.png` ou deletar | Baixo |
+| 15 | `chore: update README.md (real tech stack)` | `README.md` | Reescrever seção tecnologias (Postgres/Prisma, não JSON/MySQL); adicionar setup real | Baixo |
+| 16 | `chore: delete mock tests (api.test.js, rh.test.js)` | `backend/tests/*` | Deletar; substituir por 1 teste real de integração (próximo PR) | Baixo |
+| 17 | `chore: fix coverage folder (not committed)` | `.gitignore` | Adicionar `coverage/`; remover `backend/coverage/tmp/*` | Baixo |
+| 18 | `chore: enable ESLint on .tsx files` | `apps/web/eslint.config.js` | Adicionar `.tsx` ao `--ext`; rodar lint e corrigir | Médio — pode gerar muitos warnings |
+
+**Ao fim da Semana 2**, o repositório estará limpo de débito cosmético e seguro no que tange às 4 vulnerabilidades críticas P0.
+
+---
+
+## 3.3. Plano de refatoração incremental (Meses 1-6)
+
+O roadmap a seguir **converge com o cronograma de features do artefato 02**. Cada item é um PR em sequência de dependência. Estimativa de esforço por PR assume 1 dev sênior ou 2 devs pleno em pair.
+
+### 3.3.1. Mês 1 — Fundação e segurança
+
+**Contexto:** Semanas 1-2 foram limpeza. Semanas 3-4 montam infra CI/CD e observabilidade.
+
+| PR | Título | Fundamentação | Esforço |
+|---|---|---|---|
+| 19 | `chore(ci): add GitHub Actions workflows` | ADR-009 | M |
+| 20 | `feat(observability): integrate Sentry (backend + frontend)` | ADR-008 | S |
+| 21 | `feat(observability): integrate Axiom logger via pino` | ADR-008 | S |
+| 22 | `feat(security): install helmet and set security headers` | OWASP A05 | S |
+| 23 | `feat(security): add express-rate-limit on /login, /register, /formulario` | OWASP A04 | S |
+| 24 | `feat(db): create tb_log_auditoria model + migration` | Seção 1.2 auditoria quebrada | S |
+
+**Entregáveis:** CI verde em todo PR, alertas de erro no Sentry, rate limiting ativo, auditoria real.
+
+### 3.3.2. Mês 2 — Padronização de API e validação
+
+| PR | Título | Fundamentação | Esforço |
+|---|---|---|---|
+| 25 | `feat(api): unified response envelope { data, error, meta }` | REST uniform interface | M |
+| 26 | `feat(api): global error middleware` | Remove 40+ catch blocks duplicados | M |
+| 27 | `feat(api): Zod validation middleware` | ADR-003 | M |
+| 28 | `feat(api): Zod schemas for auth routes (register, login)` | — | S |
+| 29 | `feat(api): Zod schemas for obra routes` | — | M |
+| 30 | `feat(api): Zod schemas for diario, tarefa, financeiro, rh` | — | L |
+| 31 | `feat(storage): migrate uploads to Supabase Storage via IStorageAdapter` | ADR-002, Feature 06 | M |
+| 32 | `feat(deploy): first successful production deploy on Vercel` | Milestone | — |
+
+**Entregáveis:** Todas as rotas validadas; uploads funcionam em Vercel; produção ativa.
+
+### 3.3.3. Mês 3 — Service layer + frontend modernizado
+
+| PR | Título | Fundamentação | Esforço |
+|---|---|---|---|
+| 33 | `refactor(api): extract ObraService from controller` | Ports & Adapters | M |
+| 34 | `refactor(api): extract UserService` | — | M |
+| 35 | `refactor(api): extract DiarioService` | — | M |
+| 36 | `feat(api): add onDelete Cascade to tb_etapa, tb_requisicao, tb_usuario_obra` | Seção 1.2.4 | S |
+| 37 | `feat(api): add indexes on tb_financeiro_obra.id_obra etc.` | Seção 1.2.2 | S |
+| 38 | `feat(web): TanStack Query setup + interceptor` | ADR-005 | M |
+| 39 | `feat(web): migrate useObras to useQuery` | — | S |
+| 40 | `feat(web): shadcn/ui setup + Button/Input/Dialog/Toast` | ADR-006 | M |
+
+**Entregáveis:** Arquitetura BE em camadas; FE com cache e interceptor; primeiros shadcn componentes.
+
+### 3.3.4. Mês 4 — TypeScript progressivo + testes
+
+| PR | Título | Fundamentação | Esforço |
+|---|---|---|---|
+| 41 | `chore(ts): tsconfig.json bases + migrate backend entrypoint` | ADR-001 | M |
+| 42 | `refactor(ts): convert UserService, AuthMiddleware to TS` | — | M |
+| 43 | `refactor(ts): convert ObraService to TS` | — | M |
+| 44 | `feat(test): Vitest setup + testcontainers for Postgres` | ADR-004 | L |
+| 45 | `test(api): integration tests for auth routes` | — | M |
+| 46 | `test(api): integration tests for obra CRUD` | — | M |
+| 47 | `feat(web): DashboardDinamico refactor (split in 5+ files)` | Seção 1.3.6 | L |
+
+**Entregáveis:** 3 services em TS; cobertura de integração ≥30%; Dashboard manutenível.
+
+### 3.3.5. Mês 5 — Conclusão de refatoração e módulo de Materiais
+
+| PR | Título | Fundamentação | Esforço |
+|---|---|---|---|
+| 48 | `refactor(api): extract TarefaService, FinanceiroService, RhService` | — | L |
+| 49 | `refactor(web): consolidate view/ into pages/ (strangler)` | Seção 1.3.6 | L |
+| 50 | `feat(materials): CRUD for tb_material, tb_fabricante` | Feature 02 | L |
+| 51 | `feat(materials): CRUD for tb_material_fabricante` | — | S |
+| 52 | `test(api): integration tests for materials` | — | M |
+| 53 | `feat(web): pages for materials CRUD` | — | M |
+
+**Entregáveis:** Service layer completo; frontend unificado; módulo de Materiais no ar.
+
+### 3.3.6. Mês 6 — Consolidação e módulo de Etapas
+
+| PR | Título | Fundamentação | Esforço |
+|---|---|---|---|
+| 54 | `feat(etapas): CRUD for tb_etapa + tb_etapa_material` | Feature 03 | L |
+| 55 | `feat(web): timeline of etapas on ObraPage` | — | L |
+| 56 | `feat(obra): progresso físico calculado via tarefas de etapa` | — | M |
+| 57 | `test(e2e): Playwright setup + login + criar obra flow` | ADR-004 | L |
+| 58 | `feat(ui): adopt shadcn/ui Table, Form, DropdownMenu` | ADR-006 | M |
+| 59 | `refactor(ts): coverage ≥70% TS files` | ADR-001 | M |
+
+**Entregáveis:** Etapas funcionais; Playwright cobrindo 1 fluxo crítico; 70% TS.
+
+### 3.3.7. Visão dos meses 7-24 (resumo)
+
+Detalhamento completo está no artefato 04 (Seção 4.7 — cronograma 24 meses). Em suma:
+
+- **Mês 7-8:** Features 04 (curva S), 12 (dashboard BI)
+- **Mês 9-10:** Feature 05 (PWA offline), testes E2E restantes
+- **Mês 11-12:** Consolidação TypeScript ≥90%, documentação técnica gerada (TypeDoc + Storybook para components)
+- **Mês 13-14:** Features 07 (IA RDO), 10 (WhatsApp)
+- **Mês 15-16:** Feature 08 (IA SINAPI)
+- **Mês 17-18:** Features 09 (Chat IA), 11 (Segurança do trabalho)
+- **Mês 19-20:** Features 15 (BIM/plantas), performance (Lighthouse ≥90)
+- **Mês 21-22:** Auditoria LGPD, polimento UX, acessibilidade WCAG 2.2 AA
+- **Mês 23-24:** Documentação de defesa, vídeo demo, TCC escrito
+
+---
+
+## Conclusão da Fase 3
+
+A refatoração proposta segue 3 princípios orientadores:
+
+1. **Strangler Fig Pattern** — código novo nasce com qualidade; código velho é refatorado oportunisticamente, sem big-bang rewrite.
+2. **Last Responsible Moment** — decisões arquiteturais que podem ser adiadas são adiadas (ex: Turborepo no Mês 12+, não agora).
+3. **Fail fast, fail cheap** — CI catch 90% dos erros antes do review humano; Sentry catch os 10% restantes em produção.
+
+Os 10 ADRs propostos são **recomendações**, não dogmas. Espera-se que pelo menos 2 sejam revisitados quando a equipe estiver imersa no código e tiver mais contexto. A disciplina de manter os ADRs **versionados no repositório** (em `docs/adr/`) é parte do padrão de maturidade esperado da equipe.
+
+Os detalhes de **quem faz o quê, quando, e como o time se organiza** para executar esse roadmap estão no artefato 04.

--- a/docs/docs/auditoria-inicial/04-workflow-equipe.md
+++ b/docs/docs/auditoria-inicial/04-workflow-equipe.md
@@ -1,0 +1,558 @@
+# Fase 4 — Integração com GitHub e Fluxo de Trabalho da Equipe
+
+**Projeto:** Obra Integrada
+**Data:** 24 de abril de 2026
+**Escopo:** Branches, divisão de responsabilidades, templates GitHub, CI/CD, integração Vercel e cronograma macro de 24 meses
+
+---
+
+## Sumário executivo
+
+Este artefato formaliza **como uma equipe de 5–6 desenvolvedores** (sendo 1 com continuidade incerta) organiza o trabalho diário no projeto Obra Integrada, usando GitHub como plataforma de colaboração e Vercel como plataforma de deploy.
+
+As escolhas privilegiam **fluxos leves, automáveis e aprendíveis** em até 2 semanas: branch model baseado em `main` + feature branches (trunk-based light), proteção de branches via GitHub Rulesets, Conventional Commits para histórico legível, e 3 GitHub Actions workflows enxutos (~50 linhas cada) para garantir qualidade mínima em todo PR.
+
+A divisão de responsabilidades é **por módulo de negócio** (não por camada), com papéis fixos (Tech Lead, DevOps) e papéis rotativos (Reviewer da semana, Docs da semana). O cronograma macro de 24 meses vincula entregas a marcos acadêmicos de TCC.
+
+Todos os templates referenciados (`PULL_REQUEST_TEMPLATE.md`, `ISSUE_TEMPLATE/*.md`, `CODEOWNERS`, 3 workflows YAML e `CONTRIBUTING.md`) **foram criados junto deste artefato** — não são descrições, são arquivos funcionais na sua localização canônica.
+
+---
+
+## 4.1. Estrutura de branches recomendada
+
+### 4.1.1. Modelo escolhido: trunk-based com feature branches de vida curta
+
+O projeto adotará um modelo próximo ao **Trunk-Based Development** descrito por Paul Hammant (`trunkbaseddevelopment.com`), adaptado para equipe acadêmica que ainda não tem maturidade de deploys diários.
+
+**Características:**
+
+- **Um único branch de integração: `main`**. É sempre deployable (considerado "release-ready").
+- **Feature branches de vida curta** (<5 dias idealmente, <2 semanas no limite) — quanto mais curto, menos dor em merge.
+- **Sem `develop` separado**. Staging é um ambiente com deploy automático de `main` antes de produção.
+- **Sem `release/*` branches** — releases são feitas por tag (`v1.2.0`) diretamente de `main`.
+- **`hotfix/*`** apenas para correções urgentes em produção (raríssimo).
+
+### 4.1.2. Convenção de nomes de branches
+
+| Padrão | Exemplo | Quando usar |
+|---|---|---|
+| `feature/<modulo>-<descricao-curta>` | `feature/diario-exportar-pdf` | Nova funcionalidade |
+| `fix/<modulo>-<descricao-curta>` | `fix/auth-jwt-secret-fallback` | Correção de bug |
+| `chore/<descricao>` | `chore/delete-orphan-files` | Manutenção, deps, tooling |
+| `refactor/<area>-<descricao>` | `refactor/api-extract-obra-service` | Refatoração sem mudança funcional |
+| `docs/<descricao>` | `docs/update-readme` | Só documentação |
+| `hotfix/<descricao>` | `hotfix/login-500-error` | Bug crítico em produção |
+
+Palavras proibidas em nome de branch: números de issue como raiz do nome (preferir descrição), nomes genéricos (`feature/update`, `fix/bug`).
+
+### 4.1.3. Regras de proteção — GitHub Rulesets
+
+A proteção de `main` deve ser configurada em *Settings → Rules → Rulesets* com as seguintes regras mínimas:
+
+- **Restrict deletions**: impedir delete do branch
+- **Require linear history**: preferir `squash merge` (evita merge commits "ruído")
+- **Require pull request**:
+  - Requer aprovação de **no mínimo 1 reviewer** (2 para mudanças em áreas críticas — ver Section 4.2)
+  - Reviewer não pode ser o autor
+  - Aprovações são invalidadas em novo push
+- **Require status checks to pass**:
+  - `CI / lint`
+  - `CI / type-check`
+  - `CI / test-backend`
+  - `CI / test-frontend`
+  - `CI / build-frontend`
+  - `prisma-check`
+- **Require conversation resolution**: resolver todos comentários
+- **Require signed commits** (opcional mas recomendado): `git commit -S`
+- **Block force pushes**
+
+### 4.1.4. Merge strategies
+
+| Situação | Estratégia | Racional |
+|---|---|---|
+| Feature → main | **Squash & merge** | 1 commit limpo por PR; histórico legível |
+| Fix pequeno → main | **Squash & merge** | Idem |
+| Hotfix → main | **Squash & merge** | Idem |
+| Release tag | `git tag -a v1.2.0 -m "..."` + `git push --tags` | SemVer |
+
+**Merge commit** e **rebase merge** são **desabilitados** no GitHub para evitar confusão.
+
+### 4.1.5. Conventional Commits
+
+Todo commit segue o padrão de [Conventional Commits v1.0.0](https://www.conventionalcommits.org/):
+
+```
+<tipo>(<escopo opcional>): <descrição curta no imperativo>
+
+<corpo opcional — o porquê>
+
+<rodapé opcional — BREAKING CHANGE, Refs, Co-authored-by>
+```
+
+Tipos aceitos:
+- `feat`: nova funcionalidade
+- `fix`: correção de bug
+- `chore`: manutenção, sem impacto em app
+- `refactor`: refatoração sem mudança funcional
+- `docs`: só documentação
+- `test`: adiciona/ajusta testes
+- `perf`: melhoria de performance
+- `build`: mudanças de build/deps
+- `ci`: mudanças em CI/CD
+- `style`: formatação, sem mudança de lógica
+
+Escopo (opcional): `obras`, `diario`, `tarefas`, `financeiro`, `rh`, `admin`, `auth`, `api`, `web`, `db`, `ci`.
+
+Exemplos válidos:
+
+```
+feat(diario): add GPS audit status workflow
+fix(auth): remove JWT_SECRET hardcoded fallback
+chore(db): add tb_log_auditoria model
+refactor(api): extract ObraService from controller
+docs(adr): accept ADR-003 Zod for validation
+```
+
+Essa disciplina habilita, no futuro, **semantic-release** (versionamento automático) e **changelog** gerado automaticamente.
+
+---
+
+## 4.2. Divisão de responsabilidades entre os 5–6 membros
+
+### 4.2.1. Princípio: divisão por módulo, não por camada
+
+Em vez de ter "um dev de backend" e "um dev de frontend", cada desenvolvedor é **owner de 1–2 módulos de negócio** e escreve código nas 2 camadas desses módulos. Isso gera:
+
+- **Contexto concentrado**: o dev que faz RDO PDF (Feature 01) entende o fluxo do diário fim-a-fim
+- **Menos handoff**: não precisa esperar outro dev para avançar
+- **Review mais qualificado**: o owner de um módulo revisa mudanças na área alheia com perguntas de negócio
+
+### 4.2.2. Matriz proposta de módulos × pessoas
+
+Dada a incerteza do 6º membro, o planejamento assume **5 devs com owner principal + 1 secundário cobrindo**. Se o 6º se confirmar, assume Admin (hoje menor carga).
+
+| Módulo | Owner primário | Owner secundário (backup) | Código em |
+|---|---|---|---|
+| **Obras + Materiais + Etapas** | Dev 1 | Dev 2 | `apps/api/controllers/obra*`, `apps/api/controllers/material*`, `apps/web/src/pages/Obra/`, `apps/web/src/pages/Obras/` |
+| **Diário + Tarefas** | Dev 2 | Dev 1 | `apps/api/controllers/diario*`, `apps/api/controllers/tarefa*`, `apps/web/src/pages/Calendar*`, `apps/web/src/pages/Obra/sections/ObraDiario*` |
+| **Financeiro** | Dev 3 | Dev 5 | `apps/api/controllers/financeiro*`, `apps/web/src/pages/Obra/sections/ObraFinanceiro*` |
+| **RH + Usuários + Auth** | Dev 4 | Dev 3 | `apps/api/controllers/rh*`, `apps/api/controllers/user*`, `apps/api/middlewares/auth*`, `apps/web/src/context/AuthContext*`, `apps/web/src/pages/Operational/GestaoRH*` |
+| **Admin + Observabilidade + DevOps** | Dev 5 (Tech Lead/DevOps) | Dev 4 | `apps/api/controllers/admin*`, `.github/`, `docs/`, configs Vercel, Sentry, Axiom |
+| **IA + Integrações (a partir do Mês 13)** | Dev 6 (se existir) OU rotativo | — | `apps/api/integrations/`, `packages/ai/` |
+
+### 4.2.3. Papéis fixos
+
+| Papel | Pessoa | Responsabilidades |
+|---|---|---|
+| **Tech Lead** | Dev 5 | Decisões arquiteturais (propõe ADRs), veta/aprova PRs em áreas críticas (auth, DB schema), treina o time |
+| **DevOps / Release Manager** | Dev 5 (acumula no início; desacopla no Mês 12+) | Mantém CI/CD, gerencia Vercel, deploys, monitoring, runbook |
+| **Product Owner (acadêmico)** | Rotativo mensal entre Dev 1-4 | Prioriza backlog, escreve histórias, interlocutor com professor orientador |
+
+### 4.2.4. Papéis rotativos (semanais)
+
+Rotação semanal entre os 5 devs:
+
+| Papel | Duração | Responsabilidade |
+|---|---|---|
+| **Reviewer da semana** | Seg → Sex | Review prioritário de PRs (meta: <24h para 1º review); coordenar com outros reviewers específicos quando o PR toca vários módulos |
+| **Docs da semana** | Seg → Sex | Atualizar docs (README, CONTRIBUTING, ADRs novos se houver); cuidar que PRs mesclados tenham atualização de docs quando necessário |
+| **Oncall de bugs** | Seg → Sex | Primeira linha para issues abertas com label `bug`; tenta reprodução, atribui a owner do módulo se não conseguir resolver |
+
+A rotação é visível em `/docs/team-rotation.md` (a ser criado quando a equipe confirmar nomes).
+
+### 4.2.5. Reuniões
+
+| Tipo | Frequência | Duração | Participantes |
+|---|---|---|---|
+| **Daily async no GitHub** | Diária | — | Todos — post no Discussions |
+| **Weekly sync** | Segunda 18h | 30 min | Todos — review do sprint, impedimentos |
+| **ADR review** | Quinzenal (ou sob demanda) | 45 min | Todos — discussão de novas decisões |
+| **Retrospectiva** | A cada 4 semanas | 1h | Todos — melhoria de processo |
+| **Demo interna** | A cada 8 semanas | 1h | Todos + orientador | — |
+
+---
+
+## 4.3. Templates a criar
+
+**Estes arquivos foram criados junto deste artefato**, nas seguintes localizações:
+
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
+- [`.github/ISSUE_TEMPLATE/bug_report.md`](../../.github/ISSUE_TEMPLATE/bug_report.md)
+- [`.github/ISSUE_TEMPLATE/feature_request.md`](../../.github/ISSUE_TEMPLATE/feature_request.md)
+- [`.github/CODEOWNERS`](../../.github/CODEOWNERS)
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+
+O conteúdo canônico de cada um está nos próprios arquivos; aqui fica o racional de cada seção.
+
+### 4.3.1. Pull Request Template — racional
+
+O template guia o autor do PR a responder 4 perguntas:
+1. **O quê**: resumo em 1-2 frases
+2. **Por quê**: link para issue ou ADR
+3. **Como testar**: passos para reviewer reproduzir
+4. **Checklist**: testes, docs, screenshots (se UI)
+
+Justificativa: sem checklist, PRs "passam" com gaps (ex: esquece de atualizar README ou seed). O checklist força o autor a lembrar.
+
+### 4.3.2. Issue Templates
+
+**Bug report**: força reprodução passo-a-passo, comportamento esperado × observado, environment.
+**Feature request**: força articulação do problema do usuário (não "adicionar X" mas "usuário Y quer fazer Z porque W").
+
+### 4.3.3. CODEOWNERS
+
+CODEOWNERS mapeia o owner de cada pasta. GitHub atribui reviewers automaticamente quando um PR toca uma pasta.
+
+Nota importante: os handles nos CODEOWNERS são **placeholders (`@dev1`, `@dev2`, ...)**. A equipe deve substituir pelos handles reais do GitHub antes de ativar proteção de branch com `CODEOWNERS required`.
+
+### 4.3.4. CONTRIBUTING.md
+
+Documenta o que o dev novo precisa fazer no primeiro dia: setup local, rodar testes, padrão de commits, como abrir PR. Substitui "onboarding verbal" por texto que não envelhece de uma troca para outra.
+
+---
+
+## 4.4. GitHub Projects — configuração de board Kanban
+
+### 4.4.1. Estrutura recomendada
+
+Um único board por projeto (GitHub Projects v2), vinculado ao repositório.
+
+**Nome:** `Obra Integrada — Roadmap`
+
+**Colunas (views):**
+
+| Coluna | Definição | Limite (WIP) |
+|---|---|---|
+| **📋 Backlog** | Ideia registrada, ainda não priorizada | — |
+| **🎯 A Fazer (Sprint)** | Priorizada para sprint atual (2 semanas) | — |
+| **⚙️ Em Andamento** | Alguém pegou e está trabalhando | **6** (1.2 por dev, leve overload é OK) |
+| **🔍 Em Revisão** | PR aberto, aguardando review | 4 |
+| **✅ Concluído** | Merged na main — itens mais antigos que 30 dias são arquivados | — |
+| **⛔ Bloqueado** | Aguardando dependência externa (resposta de usuário, API de terceiro) | — |
+
+### 4.4.2. Views adicionais
+
+- **Por módulo**: agrupa cards por `Module` (label)
+- **Por pessoa**: agrupa por Assignee
+- **Roadmap 24 meses**: timeline-view usando campo customizado `Sprint` (com valores Sprint-01 ... Sprint-48, cada sprint = 2 semanas)
+
+### 4.4.3. Labels padrão
+
+**Tipo:**
+- `type: bug`
+- `type: feature`
+- `type: chore`
+- `type: refactor`
+- `type: docs`
+- `type: test`
+
+**Prioridade:**
+- `priority: P0 — critical` (bloqueia produção)
+- `priority: P1 — high`
+- `priority: P2 — medium`
+- `priority: P3 — low`
+
+**Módulo:**
+- `module: obras`
+- `module: diario`
+- `module: tarefas`
+- `module: financeiro`
+- `module: rh`
+- `module: admin`
+- `module: auth`
+- `module: devops`
+- `module: infra`
+
+**Tamanho (estimativa rápida):**
+- `size: S` (<1 dia)
+- `size: M` (1-3 dias)
+- `size: L` (4-7 dias)
+- `size: XL` (>1 semana — deveria ser quebrado)
+
+**Status especial:**
+- `good first issue` (para quando precisarmos onboarding)
+- `help wanted`
+- `needs ADR` (decisão arquitetural necessária antes de implementar)
+
+### 4.4.4. Automações recomendadas (GitHub Projects)
+
+GitHub Projects v2 tem automações built-in:
+
+| Trigger | Ação |
+|---|---|
+| Issue aberta | Auto-add ao board na coluna Backlog |
+| Issue fechada | Mover para Concluído |
+| PR aberto | Mover card linkado para Em Revisão |
+| PR merged | Mover card linkado para Concluído |
+| Draft PR aberto | Manter em Em Andamento |
+
+Configuração via *Project Settings → Workflows*.
+
+### 4.4.5. Cadência de grooming
+
+Toda sexta-feira, 30 min:
+- Revisar cards do Backlog
+- Triagem de issues novas (atribuir labels, módulo)
+- Mover itens priorizados para "A Fazer (Sprint)" para o próximo sprint
+- Arquivar itens "Concluído" com >30 dias
+
+---
+
+## 4.5. CI/CD workflows (GitHub Actions)
+
+**Os 3 workflows foram criados nos seguintes caminhos** (conteúdo completo em cada arquivo):
+
+- [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml) — lint, type-check, tests, build em todo PR
+- [`.github/workflows/preview-comment.yml`](../../.github/workflows/preview-comment.yml) — comenta URL do preview Vercel no PR
+- [`.github/workflows/prisma-check.yml`](../../.github/workflows/prisma-check.yml) — valida migrations antes de merge em `main`
+
+### 4.5.1. `ci.yml` — jobs e racional
+
+```
+jobs:
+  lint         → ESLint em apps/api e apps/web
+  type-check   → tsc --noEmit em apps/api e apps/web (quando TS estiver adotado)
+  test-backend → vitest em apps/api com Postgres via services
+  test-frontend→ vitest em apps/web
+  build        → vite build em apps/web (garante que bundle compila)
+```
+
+Usa:
+- `actions/checkout@v4`, `actions/setup-node@v4` com `cache: 'npm'`
+- `services.postgres` com image `postgres:16` e `POSTGRES_PASSWORD` / `POSTGRES_DB`
+- Timeout: 10 min por job
+
+**Por que separar em múltiplos jobs:** roda em paralelo; se um falha, os outros continuam — feedback mais rápido ao dev. Custo em minutos do GitHub Actions é o mesmo (só somam tempo dentro do limite).
+
+### 4.5.2. `preview-comment.yml` — racional
+
+Vercel já cria preview automaticamente para todo PR e posta um comentário no PR. **Este workflow é redundante?** Não — ele complementa com um comentário customizado que inclui:
+- URL da preview
+- Status do health check (`GET /api/admin/health` do preview)
+- Link direto para páginas críticas (`/login`, `/dashboard`, `/obras`)
+
+Isso reduz atrito do reviewer, que clica direto em "testar o fluxo" em vez de navegar.
+
+### 4.5.3. `prisma-check.yml` — racional
+
+Problema a evitar: **PR de feature que adiciona campo ao schema `.prisma` mas esquece de gerar migration**. Se mergeado, produção quebra.
+
+Este workflow verifica:
+1. Se `schema.prisma` mudou desde a base do PR
+2. Se mudou, alguma migration em `prisma/migrations/` também foi adicionada?
+3. Se `prisma.schema` e migrations estão sincronizados (`prisma migrate diff`)
+
+Falha o check (bloqueia merge) se as regras não são atendidas.
+
+---
+
+## 4.6. Integração Vercel ↔ GitHub — passo a passo
+
+Vercel permite **2 projetos distintos apontando para o mesmo repositório**, um para o frontend e outro para o backend. É exatamente o que o Obra Integrada precisa.
+
+### 4.6.1. Criar os projetos
+
+**Projeto 1 — Backend (API)**
+
+1. Acesse [vercel.com/new](https://vercel.com/new) e importe o repo `obra-integrada`
+2. Em *Configure Project*:
+   - **Project Name**: `obra-integrada-api`
+   - **Framework Preset**: `Other` (Vercel detecta Express)
+   - **Root Directory**: `apps/api` (após ADR-007 restructure) ou `backend` (antes)
+   - **Build Command**: `npm install && npx prisma generate` (postinstall já cobre)
+   - **Output Directory**: (deixar vazio)
+   - **Install Command**: `npm install`
+3. Em *Environment Variables*:
+   - Adicionar todas as variáveis da Seção 1.5.4 do artefato 01
+4. Deploy
+
+**Projeto 2 — Frontend (Web)**
+
+1. [vercel.com/new](https://vercel.com/new) novamente, mesmo repo
+2. Em *Configure Project*:
+   - **Project Name**: `obra-integrada-web`
+   - **Framework Preset**: `Vite`
+   - **Root Directory**: `apps/web` (ou `frontend/vite-project`)
+   - **Build Command**: `npm run build`
+   - **Output Directory**: `dist`
+3. Variáveis de ambiente:
+   - `VITE_API_URL` → apontar para URL do projeto 1
+   - Outras `VITE_*` conforme a Seção 1.5.4
+4. Deploy
+
+### 4.6.2. Ignored Build Step — otimização
+
+Para **não buildar a Vercel inteira quando um PR só toca o outro projeto**, configurar *Ignored Build Step* em cada projeto:
+
+**No projeto `obra-integrada-api`**, colar em *Settings → Git → Ignored Build Step*:
+
+```bash
+git diff HEAD^ HEAD --quiet -- apps/api/ backend/
+```
+
+Se o comando acima retornar 0 (nenhuma mudança na pasta), a Vercel pula o build.
+
+**No projeto `obra-integrada-web`**, análogo:
+
+```bash
+git diff HEAD^ HEAD --quiet -- apps/web/ frontend/
+```
+
+Isso economiza minutos de build em PRs que só tocam um lado.
+
+### 4.6.3. Domínios e ambientes
+
+| Ambiente | Projeto | Domínio | Branch |
+|---|---|---|---|
+| **Produção** | obra-integrada-web | `obra-integrada.vercel.app` (e futuro `obraintegrada.com.br`) | `main` |
+| **Produção** | obra-integrada-api | `obra-integrada-api.vercel.app` (e `api.obraintegrada.com.br`) | `main` |
+| **Preview** | ambos | `<project>-<branch>-<team>.vercel.app` (automático) | qualquer branch |
+| **Staging** | ambos | `staging.obra-integrada.vercel.app` | `main` (com domain assignment) |
+
+**⚠ Nota sobre domínios:** os `*.vercel.app` são **placeholders**. Se a equipe registrar um domínio próprio (ex: `obraintegrada.com.br`), reconfigurar em *Project → Domains*.
+
+### 4.6.4. Variáveis de ambiente por ambiente
+
+Em cada projeto Vercel, *Settings → Environment Variables* suporta 3 escopos: **Production**, **Preview**, **Development** (o último é injetado ao rodar `vercel dev` localmente).
+
+Estratégia:
+
+| Variável | Production | Preview | Development |
+|---|---|---|---|
+| `DATABASE_URL` | DB produção | DB preview (Neon branch) | DB dev local |
+| `JWT_SECRET` | secret real (gerado com `openssl rand -base64 48`) | secret de teste | secret de teste |
+| `FRONTEND_URL` | `https://obra-integrada.vercel.app` | `https://*.vercel.app` (padrão permissivo para preview) | `http://localhost:5173` |
+| `SENTRY_DSN` | DSN produção | DSN produção (ou ambiente separado) | vazio (desliga) |
+| `STORAGE_PROVIDER` | `supabase` | `supabase` | `local` |
+
+### 4.6.5. Deploy automático por branch
+
+Default da Vercel já é:
+- Push em `main` → deploy para Production
+- Push em qualquer outra branch com PR aberto → deploy para Preview
+
+Configuração adicional recomendada em *Settings → Git*:
+- **Production Branch**: `main`
+- **Ignore Command**: como em 4.6.2
+
+### 4.6.6. Monitoramento pós-deploy
+
+Após primeiro deploy, integrar:
+- **Vercel Analytics** (free tier): métricas básicas de Core Web Vitals
+- **Vercel Log Drain → Axiom** (ADR-008): logs estruturados indexados
+- **Sentry** (ADR-008): erros em tempo real
+
+---
+
+## 4.7. Cronograma macro de 24 meses
+
+Cada "mês" abaixo equivale a ~4 semanas de trabalho de uma equipe de 5 devs. Os PRs numerados referem-se ao roadmap do artefato 03, seção 3.3.
+
+### Mês 1–2 — Fundação (PRs 1–32)
+
+**Objetivo:** repositório limpo, CI verde, primeiro deploy em produção.
+
+**Entregáveis concretos:**
+- [x] Limpeza da Semana 1-2 executada (18 PRs — Seções 3.2.1 e 3.2.2)
+- [x] GitHub Actions funcionando (`ci.yml`, `preview-comment.yml`, `prisma-check.yml`)
+- [x] Sentry + Axiom integrados
+- [x] Helmet + rate limiting + JWT fix + CORS fix
+- [x] Resposta de API padronizada (`{ data, error, meta }`)
+- [x] Middleware global de erros
+- [x] Zod em todas as rotas
+- [x] Migração uploads → Supabase Storage
+- [x] Primeiro deploy de produção com status "verde"
+- [x] `CONTRIBUTING.md`, templates, CODEOWNERS em uso
+
+### Mês 3–8 — Features principais (PRs 33–80 aprox.)
+
+**Objetivo:** construir diferenciais competitivos identificados na Fase 2.
+
+**Entregáveis por mês:**
+
+- **Mês 3**: Service layer backend; TanStack Query + shadcn/ui no frontend; Features 13 (Google Maps) e 14 (previsão do tempo) — quick wins
+- **Mês 4**: TypeScript progressivo; testes de integração Vitest+testcontainers; Feature 01 (RDO PDF)
+- **Mês 5**: Módulo de Materiais e Fabricantes (Feature 02); consolidação view/→pages/
+- **Mês 6**: Módulo de Etapas (Feature 03); primeiros testes E2E Playwright
+- **Mês 7**: Cronograma físico-financeiro com curva S (Feature 04)
+- **Mês 8**: Dashboard BI executivo (Feature 12)
+
+### Mês 9–10 — Refatoração e consolidação (PRs 81–100 aprox.)
+
+**Objetivo:** preparar base para features avançadas; pagar débito residual.
+
+**Entregáveis:**
+- PWA offline-first (Feature 05) — 3 sprints
+- Migração TypeScript ≥80% do código
+- Cobertura de testes ≥60%
+- Refresh token + logout server-side (pagar dívida do artefato 01 item 27)
+- Performance: Lighthouse ≥85 (FE), p95 latência <500ms (API)
+- Revisão da arquitetura com base em aprendizados acumulados
+
+### Mês 11–18 — Features avançadas e IA (PRs 101–180 aprox.)
+
+**Objetivo:** diferenciais de mercado que impressionam banca e destravam adoção.
+
+**Entregáveis por mês:**
+
+- **Mês 11**: Storybook dos componentes shadcn/ui; TypeDoc gerando docs de API; acessibilidade WCAG 2.1 A
+- **Mês 12**: Consolidação TS 90%+; introdução de Turborepo (se necessário); primeira release pública 1.0
+- **Mês 13**: IA — geração automática de RDO a partir de texto/voz (Feature 07)
+- **Mês 14**: WhatsApp Business (Feature 10)
+- **Mês 15**: IA — estimativa automática de materiais via SINAPI (Feature 08) — parte 1
+- **Mês 16**: IA — SINAPI parte 2; integração contábil
+- **Mês 17**: Chat IA para trabalhadores (Feature 09)
+- **Mês 18**: Módulo Segurança do Trabalho NR-18/EPI (Feature 11)
+
+### Mês 19–22 — Polimento e robustez (PRs 181–220 aprox.)
+
+**Objetivo:** transformar produto funcional em produto maduro.
+
+**Entregáveis:**
+- **Mês 19**: Feature 15 (biblioteca de plantas + BIM viewer básico)
+- **Mês 20**: Performance — bundle <400KB FE, p95 <300ms API; cache com Redis
+- **Mês 21**: Auditoria LGPD completa; termo de consentimento; export de dados (DPO-ready)
+- **Mês 22**: Acessibilidade WCAG 2.2 AA; i18n se houver demanda (ADR específico)
+
+### Mês 23–24 — Apresentação final (PRs 221–240 aprox.)
+
+**Objetivo:** empacotar para defesa acadêmica com qualidade profissional.
+
+**Entregáveis:**
+- **Mês 23**:
+  - Documentação escrita de TCC — ~80 páginas, revisada por orientador
+  - Arquitetura documentada (diagramas C4 model)
+  - Vídeo demo 5-10 min (roteiro + gravação + edição)
+  - Landing page de apresentação
+  - Preparação de infraestrutura para público (rate limits ajustados, captcha em registro, termos de uso)
+- **Mês 24**:
+  - Apresentação ensaiada
+  - Bug bash final (time caça e corrige 20+ bugs de polimento)
+  - Tag v1.0 de defesa
+  - Backup completo do repositório
+  - Pós-defesa: retrospectiva e decisão sobre futuro do produto
+
+### 4.7.1. Marcos acadêmicos sugeridos
+
+Alinhados ao cronograma acima. Ajustar conforme calendário real da instituição:
+
+| Marco | Quando | Entregável |
+|---|---|---|
+| Banca de qualificação | Mês 6 | Auditoria concluída + fundação + 3 features novas (Features 01, 13, 14) + 1 refatoração completa (módulo Obras) |
+| Marco intermediário | Mês 12 | MVP 1.0 público; PWA funcionando; 8 features concluídas |
+| Pré-banca | Mês 22 | Produto completo com IA; testes ≥70%; LGPD |
+| Banca final | Mês 24 | Produto + documento + demo + defesa |
+
+---
+
+## Conclusão da Fase 4
+
+As escolhas de fluxo deste artefato privilegiam **simplicidade aprendível** sobre sofisticação. Branches simples, squash merge, Conventional Commits, 3 workflows CI enxutos, 2 projetos Vercel bem configurados. Nada aqui exige que alguém da equipe tenha experiência prévia com algum tool específico — tudo é documentável em ≤1 hora de leitura.
+
+A divisão por módulo (não por camada) é o ponto mais não-óbvio. Recomenda-se **conscientemente resistir** à tentação de "Dev A é backend, Dev B é frontend" quando o time crescer em maturidade. Ownership end-to-end cria engenheiros melhores e entregas mais rápidas.
+
+O cronograma de 24 meses é **ambicioso mas cabível** se disciplina de limpeza + testes for mantida desde o Mês 1. O maior risco de atraso é não fazer a higiene da Semana 1-2 e deixar débito técnico crescer composicionalmente.
+
+Os 8 arquivos referenciados (templates + workflows + CONTRIBUTING + CODEOWNERS) acompanham este artefato como arquivos reais no repositório. Os placeholders `@dev1`...`@dev5` no CODEOWNERS e nos textos devem ser substituídos pelos handles reais do GitHub antes do primeiro Ruleset ser ativado em `main`.
+
+Esta fase encerra a Auditoria Inicial. Próximos passos: aprovar os ADRs em sessão de equipe, começar os PRs da Semana 1, configurar os 2 projetos Vercel.

--- a/docs/docs/auditoria-inicial/README.md
+++ b/docs/docs/auditoria-inicial/README.md
@@ -1,0 +1,138 @@
+# Auditoria Inicial — Obra Integrada
+
+**Data:** 24 de abril de 2026
+**Escopo:** Auditoria arquitetural completa + roadmap estratégico de 24 meses
+**Público-alvo:** Equipe técnica (5-6 devs), orientador acadêmico, banca de TCC
+
+---
+
+## O que é isto
+
+Este diretório contém **4 artefatos de auditoria** que formam a base de referência para o desenvolvimento do Obra Integrada nos próximos 24 meses:
+
+| # | Artefato | Foco | Páginas estimadas |
+|---|---|---|---|
+| 1 | [`01-auditoria-tecnica.md`](./01-auditoria-tecnica.md) | Diagnóstico do código atual — estrutura, schema, qualidade, segurança, prontidão Vercel, débito técnico priorizado | ~18 |
+| 2 | [`02-evolucao-produto.md`](./02-evolucao-produto.md) | Análise do produto — funcionalidades atuais, benchmark competitivo BR, 15 features propostas, oportunidades arquiteturais | ~14 |
+| 3 | [`03-plano-refatoracao.md`](./03-plano-refatoracao.md) | 10 ADRs, plano de limpeza 2 semanas, refatoração incremental 6 meses | ~15 |
+| 4 | [`04-workflow-equipe.md`](./04-workflow-equipe.md) | Branches, divisão por módulo, templates GitHub, CI/CD, integração Vercel, cronograma 24 meses | ~12 |
+
+Complementarmente, foram criados **8 arquivos funcionais** no repositório durante esta auditoria:
+
+- [`.github/PULL_REQUEST_TEMPLATE.md`](../../.github/PULL_REQUEST_TEMPLATE.md)
+- [`.github/ISSUE_TEMPLATE/bug_report.md`](../../.github/ISSUE_TEMPLATE/bug_report.md)
+- [`.github/ISSUE_TEMPLATE/feature_request.md`](../../.github/ISSUE_TEMPLATE/feature_request.md)
+- [`.github/CODEOWNERS`](../../.github/CODEOWNERS)
+- [`.github/workflows/ci.yml`](../../.github/workflows/ci.yml)
+- [`.github/workflows/preview-comment.yml`](../../.github/workflows/preview-comment.yml)
+- [`.github/workflows/prisma-check.yml`](../../.github/workflows/prisma-check.yml)
+- [`CONTRIBUTING.md`](../../CONTRIBUTING.md)
+
+---
+
+## Síntese executiva
+
+### Diagnóstico (Fase 1)
+
+O Obra Integrada é **acadêmico maduro em escopo funcional** (21 entidades no schema, 10 controllers, RBAC com 8 papéis, upload de arquivos, diário com GPS), e **imaturo em disciplina de engenharia** (testes só mock, validação dispersa por regex, dependências duplicadas, 15+ arquivos órfãos, `dev.db` e cobertura commitados, JWT secret com fallback hardcoded).
+
+**6 problemas críticos de segurança** identificados (todos P0, corrigíveis na Semana 1): JWT fallback, CORS aberto, 2 rotas admin sem RBAC, uploads efêmeros na Vercel, falta de rate limit em login.
+
+**Débito total:** 33 itens catalogados em matriz Esforço × Impacto. Desses, 9 são P0 (~1 semana), 10 são P1 (~1 mês), 11 são P2 (~2-3 meses).
+
+### Oportunidades de produto (Fase 2)
+
+**2 diferenciais já presentes** que superam a média do mercado para construtoras pequenas: auditoria geográfica do diário com GPS + multi-tenancy nativo desde o schema.
+
+**Gaps competitivos principais vs. concorrentes brasileiros** (Sienge, Vobi, Obra Prima, Mobuss):
+- Sem RDO (Relatório Diário de Obra) exportável em PDF — feature básica do líder em pequenas construtoras (Obra Prima)
+- Sem integração SINAPI (tabela nacional de insumos) — diferencial Vobi
+- Sem Agentes de IA — diferencial único da Vobi
+- Sem app mobile / PWA offline — limita uso em canteiro com conexão ruim
+- 9 modelos Prisma ociosos (materiais, fabricantes, etapas) prontos para virar módulo
+
+**15 features propostas** cobrindo: paridade de mercado (RDO PDF, cronograma físico-financeiro, materiais), diferencial mobile (PWA offline, Google Maps, previsão do tempo), diferencial IA (RDO automático por voz, estimativa via SINAPI, chatbot para trabalhadores), lock-in (BI executivo, biblioteca de plantas/BIM, segurança do trabalho NR-18).
+
+### Plano de evolução (Fase 3)
+
+**10 ADRs propostos** para decisões arquiteturais pendentes:
+- ADR-001: TypeScript progressivo (strangler, meta 70% em 12 meses)
+- ADR-002: Storage com Supabase Storage (interface trocável)
+- ADR-003: Zod para validação
+- ADR-004: Testing Trophy (unit + integração com testcontainers + E2E Playwright)
+- ADR-005: TanStack Query no frontend
+- ADR-006: shadcn/ui para componentes
+- ADR-007: npm workspaces (escalar para Turborepo no Mês 12+)
+- ADR-008: Sentry + Axiom
+- ADR-009: GitHub Actions
+- ADR-010: Ambientes dev/staging/prod com Neon (Postgres com branching)
+
+**Refatoração incremental** em 59 PRs sequenciais dos Meses 1-6, convergindo com as primeiras features do produto.
+
+### Workflow de equipe (Fase 4)
+
+- **Branches:** trunk-based light, feature branches curtas, squash merge, Conventional Commits
+- **Divisão por módulo de negócio, não por camada** — cada dev owner de 1-2 módulos end-to-end
+- **Papéis fixos:** Tech Lead + DevOps (Dev 5). **Rotativos:** Reviewer da semana, Docs da semana, Oncall de bugs
+- **CI/CD:** 3 workflows — ci.yml, preview-comment.yml, prisma-check.yml
+- **Vercel:** 2 projetos no mesmo repo (web + api), previews por PR, ignored build step por pasta
+- **Cronograma 24 meses:** Meses 1-2 fundação → 3-8 features principais → 9-10 consolidação → 11-18 features avançadas e IA → 19-22 polimento → 23-24 defesa
+
+---
+
+## Como ler estes artefatos
+
+**Se você é:**
+
+- **Gerente / orientador:** comece por este README; vá direto às conclusões de cada fase.
+- **Tech Lead (Dev 5):** leia os 4 documentos em ordem; priorize ADRs da Fase 3 e cronograma da Fase 4.
+- **Dev entrando no projeto:** comece por `CONTRIBUTING.md` na raiz; volte aqui para a Seção 1.1 (mapa do código) de `01-auditoria-tecnica.md`.
+- **Product Owner:** leia `02-evolucao-produto.md` primeiro; volte para 1.1 se precisar entender o que já existe.
+- **Banca acadêmica / avaliador externo:** os 4 documentos em ordem cobrem tudo.
+
+---
+
+## Pontos de atenção
+
+### Placeholders a substituir antes de ativar proteções
+
+- Em `.github/CODEOWNERS`, substituir `@dev1`...`@dev5` pelos handles reais do GitHub
+- Em `docs/auditoria-inicial/04-workflow-equipe.md` Seção 4.2, alinhar nomes reais
+- Em `preview-comment.yml` (Seção 4.5), confirmar nomes dos projetos Vercel reais (`obra-integrada-web`, `obra-integrada-api`) antes de ativar
+
+### Suposições que podem ser reavaliadas pela equipe
+
+- **Stack de Postgres** (ADR-010): escolha entre Neon, Supabase, Railway depende do custo aceitável e de decisão sobre ADR-002 (storage) — se Supabase para storage, natural usar Supabase para Postgres também.
+- **ADR-001 TypeScript**: alguns membros podem preferir JS puro. Decisão final deve ser discutida em reunião antes do Mês 3.
+- **Divisão por módulo vs. por camada** (Seção 4.2): requer buy-in do time. Se alguém tem aversão, discutir antes do primeiro sprint.
+
+### Decisões que a equipe ainda precisa tomar
+
+1. **Handles GitHub reais** — substituir placeholders em CODEOWNERS
+2. **Domínio do produto** — `obra-integrada.vercel.app` é placeholder; se houver domínio próprio, reconfigurar
+3. **Provedor de Postgres** — Neon × Supabase × Railway
+4. **Adoção de TypeScript** — aceitar ADR-001 ou manter JS
+5. **6º membro** — se confirmar continuidade, atribuir módulo (sugestão: Admin + IA/Integrações a partir do Mês 13)
+
+---
+
+## Próximos passos imediatos
+
+1. **Sessão de equipe** (1 hora) para ler este README e decidir a posição sobre os ADRs
+2. **Substituir placeholders** no CODEOWNERS e Seção 4.2
+3. **Abrir o primeiro PR da Semana 1** (`chore: remove orphaned server.js and legacy files`) — o mais simples da lista P0
+4. **Configurar os 2 projetos Vercel** conforme Seção 4.6
+5. **Adicionar `JWT_SECRET` e outras vars** em cada ambiente conforme Seção 1.5.4
+6. **Ativar Rulesets de proteção** de `main` conforme Seção 4.1.3
+
+A partir daí, os 59 PRs do roadmap dos Meses 1-6 (Seção 3.3) são o caminho.
+
+---
+
+## Histórico deste documento
+
+| Versão | Data | Autor | Mudança |
+|---|---|---|---|
+| 1.0 | 2026-04-24 | Auditoria externa (consultoria) | Criação inicial dos 4 artefatos + templates + workflows |
+
+Atualizações futuras desta auditoria devem ser feitas por **complemento** (novos documentos ou seções novas), não por reescrita — para preservar o registro histórico dos gaps que motivaram cada decisão.


### PR DESCRIPTION
## O que foi feito

Adiciona os 5 artefatos da auditoria tecnica externa realizada em abril/2026 na pasta `docs/docs/auditoria-inicial/`:

- `README.md` — sintese executiva e como ler os artefatos
- `01-auditoria-tecnica.md` — diagnostico de codigo, schema, qualidade, seguranca
- `02-evolucao-produto.md` — analise de produto, benchmark, 15 features propostas
- `03-plano-refatoracao.md` — 10 ADRs e plano de refatoracao incremental
- `04-workflow-equipe.md` — divisao por modulo, templates, CI/CD, cronograma

## Por que

Esses arquivos ja existiam no disco mas nunca foram commitados. O README do projeto referencia esses caminhos como documentacao tecnica oficial — sem este PR, esses links ficam quebrados.

## Como testar

1. Verificar que os 5 arquivos existem em `docs/docs/auditoria-inicial/`
2. Abrir cada um e conferir que renderiza no GitHub
3. Conferir que os links cruzados entre os documentos funcionam

## Referencias

Esses documentos sao a base de planejamento do projeto para os proximos 24 meses, mencionados em varias issues do backlog.