### PR TITLE
fix(rh-pessoas): contadores, sub-nav, botoes e filtros Obra/Gestor do modulo Pessoas

### DIFF
--- a/backend/src/controllers/rhController.js
+++ b/backend/src/controllers/rhController.js
@@ -76,7 +76,18 @@ export async function listarFuncionarios(req, res) {
           cnpj_empreiteira: true,
           razao_social_empreiteira: true,
           tipo_vinculo: true,
-          lgpd_consentimento: true
+          lgpd_consentimento: true,
+          tb_usuario_obra: {
+            select: {
+              tb_obra: {
+                select: {
+                  nome: true,
+                  // Responsável da obra = gestor derivado (dado existente, sem nova regra).
+                  tb_usuario: { select: { nome: true } }
+                }
+              }
+            }
+          }
         }
       }),
       prisma.tb_usuario.count({ where })
@@ -91,8 +102,17 @@ export async function listarFuncionarios(req, res) {
       }
     }).catch(err => console.error('[AUDITORIA] Erro ao gravar log:', err));
 
+    // Expõe a obra alocada (aditivo — não altera filtros nem regra de negócio).
+    const funcionariosComObra = funcionarios.map((f) => {
+      const { tb_usuario_obra, ...rest } = f;
+      const vinculos = tb_usuario_obra || [];
+      const obras = vinculos.map((uo) => uo.tb_obra?.nome).filter(Boolean);
+      const gestores = vinculos.map((uo) => uo.tb_obra?.tb_usuario?.nome).filter(Boolean);
+      return { ...rest, obra_atual: obras[0] || null, obras, gestor: gestores[0] || null };
+    });
+
     return res.status(200).json({
-      data: funcionarios,
+      data: funcionariosComObra,
       meta: {
         total,
         page: pageNumber,

--- a/frontend/vite-project/src/pages/RH/Pessoas/ColaboradoresPage.jsx
+++ b/frontend/vite-project/src/pages/RH/Pessoas/ColaboradoresPage.jsx
@@ -29,8 +29,7 @@ export default function ColaboradoresPage() {
   const [showFiltros, setShowFiltros] = useState(false);
   const [actionMenu, setActionMenu] = useState(null);
   const [filtros, setFiltros] = useState({
-    status: 'TODOS', cargo: '', obra: '', departamento: '',
-    empresa: '', gestor: '', tipoContrato: '',
+    status: 'TODOS', cargo: '', obra: '', gestor: '', tipoContrato: '',
   });
 
   // --- perfil inline (substitui navigate) ---
@@ -60,32 +59,36 @@ export default function ColaboradoresPage() {
       const res = await apiFetch(`${API_BASE_URL}/api/rh?${params}`);
       if (!res.ok) throw new Error('Erro ao carregar colaboradores');
       const data = await res.json();
-      let lista = (data.data || []).filter((c) => !c.is_terceirizado);
-
-      if (filtros.obra)        lista = lista.filter((c) => (c.obra_atual || '').toLowerCase().includes(filtros.obra.toLowerCase()));
-      if (filtros.departamento) lista = lista.filter((c) => (c.departamento || 'Obras').toLowerCase().includes(filtros.departamento.toLowerCase()));
-      if (filtros.gestor)       lista = lista.filter((c) => (c.gestor || '').toLowerCase().includes(filtros.gestor.toLowerCase()));
-      if (filtros.tipoContrato) lista = lista.filter((c) => c.tipo_vinculo === filtros.tipoContrato);
-
+      const lista = (data.data || []).filter((c) => !c.is_terceirizado);
       setColaboradores(lista);
     } catch (err) {
       console.error(err);
     } finally {
       setLoading(false);
     }
-  }, [apiFetch, searchTerm, filtros.cargo, filtros.obra, filtros.departamento, filtros.gestor, filtros.tipoContrato]);
+  }, [apiFetch, searchTerm, filtros.cargo]);
 
   useEffect(() => {
     const t = setTimeout(carregarColaboradores, 300);
     return () => clearTimeout(t);
   }, [carregarColaboradores]);
 
-  // Lista exibida = base completa filtrada pelo status no cliente.
-  // As contagens (pílulas) usam a base completa, então não zeram ao trocar de aba.
+  // Filtros client-side (obra/gestor/contrato) sobre a base completa.
+  const baseList = colaboradores.filter((c) => {
+    if (filtros.obra && !(c.obra_atual || '').toLowerCase().includes(filtros.obra.toLowerCase())) return false;
+    if (filtros.gestor && !(c.gestor || '').toLowerCase().includes(filtros.gestor.toLowerCase())) return false;
+    if (filtros.tipoContrato && c.tipo_vinculo !== filtros.tipoContrato) return false;
+    return true;
+  });
+
+  // Lista exibida = base filtrada pelo status. As contagens usam a base,
+  // então não zeram ao trocar de aba.
   const colaboradoresFiltrados =
-    filtros.status === 'TODOS'
-      ? colaboradores
-      : colaboradores.filter((c) => c.status === filtros.status);
+    filtros.status === 'TODOS' ? baseList : baseList.filter((c) => c.status === filtros.status);
+
+  // Opções distintas para os dropdowns (da base completa, independem dos filtros).
+  const obrasDisponiveis = [...new Set(colaboradores.map((c) => c.obra_atual).filter(Boolean))].sort();
+  const gestoresDisponiveis = [...new Set(colaboradores.map((c) => c.gestor).filter(Boolean))].sort();
 
   // ---------------------------------------------------------------- handlers
   const handleCriar = async (e) => {
@@ -144,7 +147,7 @@ export default function ColaboradoresPage() {
     a.click();
   };
 
-  const contagemStatus = (s) => s === 'TODOS' ? colaboradores.length : colaboradores.filter((c) => c.status === s).length;
+  const contagemStatus = (s) => s === 'TODOS' ? baseList.length : baseList.filter((c) => c.status === s).length;
 
   const abrirPerfil = (col) => { setActionMenu(null); setPerfilAtivo(col); };
 
@@ -232,23 +235,48 @@ export default function ColaboradoresPage() {
       {/* Filtros avançados */}
       {showFiltros && (
         <div className="mb-4 p-4 bg-card border border-border rounded-xl shadow-sm grid grid-cols-2 md:grid-cols-3 lg:grid-cols-5 gap-3">
-          {[
-            { key: 'cargo', label: 'Cargo', placeholder: 'Ex: Pedreiro' },
-            { key: 'obra', label: 'Obra', placeholder: 'Ex: Residencial Alpha' },
-            { key: 'departamento', label: 'Departamento', placeholder: 'Ex: Obras' },
-            { key: 'gestor', label: 'Gestor', placeholder: 'Nome do gestor' },
-          ].map((f) => (
-            <div key={f.key}>
-              <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">{f.label}</label>
-              <input
-                type="text"
-                placeholder={f.placeholder}
-                value={filtros[f.key]}
-                onChange={(e) => setFiltros((prev) => ({ ...prev, [f.key]: e.target.value }))}
-                className="w-full mt-1 px-3 py-1.5 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring/30"
-              />
-            </div>
-          ))}
+          <div>
+            <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Cargo</label>
+            <input
+              type="text"
+              placeholder="Ex: Pedreiro"
+              value={filtros.cargo}
+              onChange={(e) => setFiltros((prev) => ({ ...prev, cargo: e.target.value }))}
+              className="w-full mt-1 px-3 py-1.5 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring/30"
+            />
+          </div>
+          <div>
+            <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Obra</label>
+            <input
+              type="text"
+              list="obras-list"
+              placeholder="Todas as obras"
+              value={filtros.obra}
+              onChange={(e) => setFiltros((prev) => ({ ...prev, obra: e.target.value }))}
+              className="w-full mt-1 px-3 py-1.5 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring/30"
+            />
+            <datalist id="obras-list">
+              {obrasDisponiveis.map((o) => (
+                <option key={o} value={o} />
+              ))}
+            </datalist>
+          </div>
+          <div>
+            <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Gestor</label>
+            <input
+              type="text"
+              list="gestores-list"
+              placeholder="Todos os gestores"
+              value={filtros.gestor}
+              onChange={(e) => setFiltros((prev) => ({ ...prev, gestor: e.target.value }))}
+              className="w-full mt-1 px-3 py-1.5 bg-background border border-border rounded-lg text-sm focus:outline-none focus:ring-2 focus:ring-ring/30"
+            />
+            <datalist id="gestores-list">
+              {gestoresDisponiveis.map((g) => (
+                <option key={g} value={g} />
+              ))}
+            </datalist>
+          </div>
           <div>
             <label className="text-[11px] font-medium text-muted-foreground uppercase tracking-wide">Contrato</label>
             <select

--- a/frontend/vite-project/src/pages/RH/Pessoas/ColaboradoresPage.jsx
+++ b/frontend/vite-project/src/pages/RH/Pessoas/ColaboradoresPage.jsx
@@ -53,7 +53,7 @@ export default function ColaboradoresPage() {
       setLoading(true);
       const params = new URLSearchParams({
         page: '1', limit: '500', busca: searchTerm,
-        status: filtros.status, sortBy: 'nome', sortOrder: 'asc',
+        status: 'TODOS', sortBy: 'nome', sortOrder: 'asc',
       });
       if (filtros.cargo) params.set('cargo', filtros.cargo);
 
@@ -73,12 +73,19 @@ export default function ColaboradoresPage() {
     } finally {
       setLoading(false);
     }
-  }, [apiFetch, searchTerm, filtros]);
+  }, [apiFetch, searchTerm, filtros.cargo, filtros.obra, filtros.departamento, filtros.gestor, filtros.tipoContrato]);
 
   useEffect(() => {
     const t = setTimeout(carregarColaboradores, 300);
     return () => clearTimeout(t);
   }, [carregarColaboradores]);
+
+  // Lista exibida = base completa filtrada pelo status no cliente.
+  // As contagens (pílulas) usam a base completa, então não zeram ao trocar de aba.
+  const colaboradoresFiltrados =
+    filtros.status === 'TODOS'
+      ? colaboradores
+      : colaboradores.filter((c) => c.status === filtros.status);
 
   // ---------------------------------------------------------------- handlers
   const handleCriar = async (e) => {
@@ -125,7 +132,7 @@ export default function ColaboradoresPage() {
   const handleExportar = () => {
     const csv = [
       ['Nome', 'Matrícula', 'Cargo', 'Status', 'Admissão', 'Email'],
-      ...colaboradores.map((c) => [
+      ...colaboradoresFiltrados.map((c) => [
         c.nome, c.matricula, c.cargo_base || '', c.status,
         c.data_admissao ? new Date(c.data_admissao).toLocaleDateString('pt-BR') : '', c.email || '',
       ]),
@@ -275,10 +282,10 @@ export default function ColaboradoresPage() {
             <tbody className="divide-y divide-border">
               {loading ? (
                 <tr><td colSpan={7} className="px-4 py-12 text-center text-sm text-muted-foreground">Carregando...</td></tr>
-              ) : colaboradores.length === 0 ? (
+              ) : colaboradoresFiltrados.length === 0 ? (
                 <tr><td colSpan={7} className="px-4 py-12 text-center text-sm text-muted-foreground">Nenhum colaborador encontrado</td></tr>
               ) : (
-                colaboradores.map((col) => (
+                colaboradoresFiltrados.map((col) => (
                   <tr
                     key={col.id_usuario}
                     className="hover:bg-muted/50 transition-colors cursor-pointer"

--- a/frontend/vite-project/src/pages/RH/Pessoas/EquipesPage.jsx
+++ b/frontend/vite-project/src/pages/RH/Pessoas/EquipesPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
-import { Users, Plus, Filter, TrendingUp, ClipboardCheck, FileCheck, Edit2, Trash2, X, UserPlus } from 'lucide-react';
+import { Users, Plus, TrendingUp, ClipboardCheck, FileCheck, Edit2, Trash2, X, UserPlus } from 'lucide-react';
 import { PageHeader, StatusBadge, SectionCard, InfoGrid, DataTable, SideIndicatorCard } from '../../../components/RH/rhUi.jsx';
+import RHPessoasNav from '../../../components/RH/RHPessoasNav.jsx';
 import { Modal } from '../../../components/ui/modal/index.tsx';
 
 const INITIAL_EQUIPES = [
@@ -65,7 +66,8 @@ export default function EquipesPage() {
   const [equipes, setEquipes] = useState(INITIAL_EQUIPES);
   const [equipeSelecionada, setEquipeSelecionada] = useState(null);
   const [filtro, setFiltro] = useState('todas');
-  
+  const [obraFiltro, setObraFiltro] = useState('');
+
   // Estados para Modal de Edição
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [equipeEmEdicao, setEquipeEmEdicao] = useState(null);
@@ -344,8 +346,11 @@ export default function EquipesPage() {
     );
   }
 
+  const obrasDasEquipes = [...new Set(equipes.map((e) => e.obra))];
+
   return (
     <div className="min-h-screen bg-background p-4 sm:p-6">
+      <div className="mb-6"><RHPessoasNav /></div>
       <PageHeader
         icon={Users}
         title="Equipes"
@@ -372,9 +377,18 @@ export default function EquipesPage() {
             {f.label}
           </button>
         ))}
-        <button className="flex items-center gap-2 px-4 py-2 bg-card border border-border rounded-lg text-sm hover:bg-accent ml-auto transition-colors">
-          <Filter size={16} /> Filtros
-        </button>
+        {filtro === 'por-obra' && (
+          <select
+            value={obraFiltro}
+            onChange={(e) => setObraFiltro(e.target.value)}
+            className="ml-auto px-4 py-2 bg-card border border-border rounded-lg text-sm text-foreground outline-none focus:ring-2 focus:ring-primary/20"
+          >
+            <option value="">Todas as obras</option>
+            {obrasDasEquipes.map((o) => (
+              <option key={o} value={o}>{o}</option>
+            ))}
+          </select>
+        )}
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-5">
@@ -382,6 +396,7 @@ export default function EquipesPage() {
           .filter(eq => {
             if (filtro === 'proprias') return eq.tipo === 'Própria';
             if (filtro === 'terceirizadas') return eq.tipo === 'Terceirizada';
+            if (filtro === 'por-obra' && obraFiltro) return eq.obra === obraFiltro;
             return true;
           })
           .map((equipe) => (

--- a/frontend/vite-project/src/pages/RH/Pessoas/OrganogramaPage.jsx
+++ b/frontend/vite-project/src/pages/RH/Pessoas/OrganogramaPage.jsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { GitBranch, ChevronDown, ChevronRight, Mail, Phone, Users } from 'lucide-react';
 import { PageHeader, SectionCard } from '../../../components/RH/rhUi.jsx';
+import RHPessoasNav from '../../../components/RH/RHPessoasNav.jsx';
 
 const ORGANOGRAMA = {
   id: 'dir',
@@ -131,6 +132,7 @@ export default function OrganogramaPage() {
 
   return (
     <div className="min-h-screen bg-background p-4 sm:p-6">
+      <div className="mb-6"><RHPessoasNav /></div>
       <PageHeader
         icon={GitBranch}
         title="Organograma"

--- a/frontend/vite-project/src/pages/RH/Pessoas/TerceirizadosPage.jsx
+++ b/frontend/vite-project/src/pages/RH/Pessoas/TerceirizadosPage.jsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
-import { Building2, Plus, Filter, Download, Users, FileText, Phone, Mail, Calendar } from 'lucide-react';
+import { Building2, Plus, Download, Users, FileText, Phone, Mail, Calendar, X } from 'lucide-react';
 import { PageHeader, StatusBadge, SectionCard, InfoGrid, DataTable } from '../../../components/RH/rhUi.jsx';
+import RHPessoasNav from '../../../components/RH/RHPessoasNav.jsx';
+import { Modal } from '../../../components/ui/modal/index.tsx';
 
-const EMPRESAS = [
+const INITIAL_EMPRESAS = [
   {
     id: 1,
     razaoSocial: 'TecniEletra Serviços Ltda',
@@ -45,12 +47,45 @@ const EMPRESAS = [
 ];
 
 export default function TerceirizadosPage() {
+  const [empresas, setEmpresas] = useState(INITIAL_EMPRESAS);
   const [empresaSelecionada, setEmpresaSelecionada] = useState(null);
   const [busca, setBusca] = useState('');
+  const [showNovoModal, setShowNovoModal] = useState(false);
+  const [novaEmpresa, setNovaEmpresa] = useState({
+    razaoSocial: '', cnpj: '', responsavel: '', telefone: '', email: '', contrato: '', vigencia: '',
+  });
 
-  const empresasFiltradas = EMPRESAS.filter((e) =>
+  const empresasFiltradas = empresas.filter((e) =>
     !busca || e.razaoSocial.toLowerCase().includes(busca.toLowerCase()) || e.cnpj.includes(busca)
   );
+
+  const handleCriarEmpresa = (e) => {
+    e.preventDefault();
+    const newId = empresas.length ? Math.max(...empresas.map((emp) => emp.id)) + 1 : 1;
+    setEmpresas((prev) => [
+      ...prev,
+      { id: newId, ...novaEmpresa, status: 'Ativa', colaboradores: [], documentos: [] },
+    ]);
+    setNovaEmpresa({ razaoSocial: '', cnpj: '', responsavel: '', telefone: '', email: '', contrato: '', vigencia: '' });
+    setShowNovoModal(false);
+  };
+
+  const handleExportar = () => {
+    const escape = (v) => `"${String(v ?? '').replace(/"/g, '""')}"`;
+    const linhas = [
+      ['Razão Social', 'CNPJ', 'Responsável', 'Telefone', 'Email', 'Contrato', 'Vigência', 'Status', 'Colaboradores'],
+      ...empresasFiltradas.map((emp) => [
+        emp.razaoSocial, emp.cnpj, emp.responsavel, emp.telefone, emp.email,
+        emp.contrato, emp.vigencia, emp.status, emp.colaboradores.length,
+      ]),
+    ];
+    const csv = linhas.map((r) => r.map(escape).join(',')).join('\n');
+    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const a = document.createElement('a');
+    a.href = URL.createObjectURL(blob);
+    a.download = `terceirizados_${new Date().toISOString().split('T')[0]}.csv`;
+    a.click();
+  };
 
   if (empresaSelecionada) {
     const emp = empresaSelecionada;
@@ -107,12 +142,16 @@ export default function TerceirizadosPage() {
 
   return (
     <div className="min-h-screen bg-muted/20 p-4 sm:p-6">
+      <div className="mb-6"><RHPessoasNav /></div>
       <PageHeader
         icon={Building2}
         title="Terceirizados"
         subtitle="Gestão de empresas contratadas e profissionais alocados"
         actions={
-          <button className="flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:opacity-90 text-sm font-semibold">
+          <button
+            onClick={() => setShowNovoModal(true)}
+            className="flex items-center gap-2 bg-primary text-primary-foreground px-4 py-2 rounded-lg hover:opacity-90 text-sm font-semibold"
+          >
             <Plus size={18} /> Nova Empresa
           </button>
         }
@@ -126,10 +165,10 @@ export default function TerceirizadosPage() {
           onChange={(e) => setBusca(e.target.value)}
           className="flex-1 min-w-[200px] px-4 py-2 bg-card border border-border rounded-lg text-sm placeholder:text-muted-foreground text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20"
         />
-        <button className="flex items-center gap-2 px-4 py-2 bg-card border border-border rounded-lg text-sm hover:bg-accent text-foreground transition-colors">
-          <Filter size={16} /> Filtros
-        </button>
-        <button className="flex items-center gap-2 px-4 py-2 bg-card border border-border rounded-lg text-sm hover:bg-accent text-foreground transition-colors">
+        <button
+          onClick={handleExportar}
+          className="flex items-center gap-2 px-4 py-2 bg-card border border-border rounded-lg text-sm hover:bg-accent text-foreground transition-colors"
+        >
           <Download size={16} /> Exportar
         </button>
       </div>
@@ -206,6 +245,47 @@ export default function TerceirizadosPage() {
           </div>
         ))}
       </div>
+
+      <Modal isOpen={showNovoModal} onClose={() => setShowNovoModal(false)} className="max-w-lg">
+        <form onSubmit={handleCriarEmpresa} className="p-6">
+          <div className="flex items-center justify-between mb-6">
+            <h2 className="text-xl font-bold text-foreground">Nova Empresa Terceirizada</h2>
+            <button type="button" onClick={() => setShowNovoModal(false)} className="text-muted-foreground hover:text-foreground">
+              <X size={20} />
+            </button>
+          </div>
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 mb-6">
+            {[
+              { key: 'razaoSocial', label: 'Razão Social', required: true, full: true },
+              { key: 'cnpj', label: 'CNPJ' },
+              { key: 'responsavel', label: 'Responsável' },
+              { key: 'telefone', label: 'Telefone' },
+              { key: 'email', label: 'Email', type: 'email' },
+              { key: 'contrato', label: 'Contrato' },
+              { key: 'vigencia', label: 'Vigência' },
+            ].map((f) => (
+              <div key={f.key} className={`space-y-1 ${f.full ? 'sm:col-span-2' : ''}`}>
+                <label className="text-xs font-bold text-muted-foreground uppercase tracking-wider">{f.label}</label>
+                <input
+                  type={f.type || 'text'}
+                  required={f.required}
+                  value={novaEmpresa[f.key]}
+                  onChange={(e) => setNovaEmpresa({ ...novaEmpresa, [f.key]: e.target.value })}
+                  className="w-full bg-background border border-border rounded-lg px-3 py-2 text-sm focus:ring-2 focus:ring-primary/20 outline-none"
+                />
+              </div>
+            ))}
+          </div>
+          <div className="flex justify-end gap-3 pt-4 border-t border-border">
+            <button type="button" onClick={() => setShowNovoModal(false)} className="px-4 py-2 text-sm font-medium text-muted-foreground hover:bg-accent rounded-lg transition-colors">
+              Cancelar
+            </button>
+            <button type="submit" className="px-6 py-2 bg-primary text-primary-foreground rounded-lg text-sm font-bold hover:opacity-90 transition-all">
+              Salvar Empresa
+            </button>
+          </div>
+        </form>
+      </Modal>
     </div>
   );
 }

--- a/frontend/vite-project/src/pages/RH/Pessoas/TerceirizadosPage.jsx
+++ b/frontend/vite-project/src/pages/RH/Pessoas/TerceirizadosPage.jsx
@@ -79,8 +79,9 @@ export default function TerceirizadosPage() {
         emp.contrato, emp.vigencia, emp.status, emp.colaboradores.length,
       ]),
     ];
-    const csv = linhas.map((r) => r.map(escape).join(',')).join('\n');
-    const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
+    const csv = linhas.map((r) => r.map(escape).join(';')).join('\r\n');
+    // Prefixa BOM (U+FEFF) p/ o Excel abrir como UTF-8; ';' e o separador padrao do Excel pt-BR.
+    const blob = new Blob(['﻿' + csv], { type: 'text/csv;charset=utf-8;' });
     const a = document.createElement('a');
     a.href = URL.createObjectURL(blob);
     a.download = `terceirizados_${new Date().toISOString().split('T')[0]}.csv`;
@@ -221,7 +222,9 @@ export default function TerceirizadosPage() {
                 <div>
                   <p className="text-[11px] font-semibold text-muted-foreground uppercase tracking-wider">Documentação</p>
                   <p className="text-sm font-semibold text-foreground/90 mt-0.5">
-                    {empresa.documentos.every((d) => d.status === 'Válido') ? (
+                    {empresa.documentos.length === 0 ? (
+                      <span className="text-muted-foreground font-bold">— Sem documentos</span>
+                    ) : empresa.documentos.every((d) => d.status === 'Válido') ? (
                       <span className="text-emerald-600 font-bold">✓ Completa</span>
                     ) : (
                       <span className="text-amber-600 font-bold">⚠ Parcial</span>


### PR DESCRIPTION
## O que muda
Correções do módulo Pessoas (RH) para a apresentação.

### Colaboradores
- Contadores de status deixam de zerar ao filtrar (contagem usa a base completa).
- Filtros Cargo/Obra/Gestor com campo de digitar + autocomplete (datalist).
- Remove o filtro "Departamento" (esse dado não existe no modelo).

### Terceirizados
- "Nova Empresa" e "Exportar" funcionais (CSV com BOM + `;`, abre certo no Excel pt-BR).
- Remove botão "Filtros" sem ação.
- Corrige "Documentação ✓ Completa" exibida para empresa sem documentos.

### Equipes
- Filtro "Por Obra" passa a funcionar (seletor de obra).
- Remove botão "Filtros" sem ação.

### Sub-nav
- RHPessoasNav consistente nas 4 páginas (Colaboradores, Terceirizados, Equipes, Organograma).

### Backend
- `listarFuncionarios` passa a expor `obra_atual` e `gestor` (responsável da obra) — aditivo, sem alterar where/filtros/paginação.

## Testes
- ESLint limpo nas páginas alteradas; `node --check` no controller.
- Verificado manualmente: contadores, filtros, exportação CSV, sub-nav e Obra/Gestor com backend reiniciado.