### PR TITLE
style: acabamento visual do Dashboard RH

### DIFF
--- a/backend/src/controllers/rhController.js
+++ b/backend/src/controllers/rhController.js
@@ -738,17 +738,17 @@ export async function obterDashboardStats(req, res) {
     const alertas = [];
     let alertaId = 1;
     if (certsVencidas > 0) {
-      alertas.push({ id: alertaId++, text: `${certsVencidas} documentos/certificações vencidos`, severity: 'high', link: '/rh' });
+      alertas.push({ id: alertaId++, text: `${certsVencidas} documentos/certificações vencidos`, severity: 'high', link: '/rh/certificacoes' });
     }
     if (certsVencendo > 0) {
-      alertas.push({ id: alertaId++, text: `${certsVencendo} certificações vencem em 30 dias`, severity: 'medium', link: '/rh' });
+      alertas.push({ id: alertaId++, text: `${certsVencendo} certificações vencem em 30 dias`, severity: 'medium', link: '/rh/certificacoes' });
     }
     if (semObra > 0) {
-      alertas.push({ id: alertaId++, text: `${semObra} colaboradores ativos sem obra atribuída`, severity: 'medium', link: '/rh' });
+      alertas.push({ id: alertaId++, text: `${semObra} colaboradores ativos sem obra atribuída`, severity: 'medium', link: '/rh/colaboradores' });
     }
     if (alertas.length === 0) {
-      alertas.push({ id: alertaId++, text: 'Nenhum documento vencido hoje', severity: 'medium', link: '/rh' });
-      alertas.push({ id: alertaId++, text: 'Todos os colaboradores devidamente alocados', severity: 'medium', link: '/rh' });
+      alertas.push({ id: alertaId++, text: 'Nenhum documento vencido hoje', severity: 'medium', link: '/rh-dashboard' });
+      alertas.push({ id: alertaId++, text: 'Todos os colaboradores devidamente alocados', severity: 'medium', link: '/rh-dashboard' });
     }
 
     // 3. Movimentações Recentes (Últimos 5 usuários cadastrados)
@@ -759,17 +759,16 @@ export async function obterDashboardStats(req, res) {
       select: { nome: true, cargo_base: true, data_admissao: true }
     });
 
-    const movimentacoesRecentes = ultimosUsuarios.map((u, i) => {
-      const time = u.criado_em ? new Date(u.criado_em).toLocaleTimeString('pt-BR', { hour: '2-digit', minute: '2-digit' }) : '08:00';
-      return {
-        time,
-        description: `${u.nome} (${u.cargo_base || 'Colaborador'}) foi cadastrado no sistema.`,
-        icon: 'UserPlus',
-        color: 'text-green-500'
-      };
-    });
+    const movimentacoesRecentes = ultimosUsuarios.map((u) => ({
+      data: u.data_admissao
+        ? new Date(u.data_admissao).toLocaleDateString('pt-BR', { day: '2-digit', month: 'short', year: 'numeric' })
+        : 'Data não informada',
+      description: `${u.nome} (${u.cargo_base || 'Colaborador'}) foi cadastrado no sistema.`,
+      icon: 'UserPlus',
+      color: 'text-green-500'
+    }));
     if (movimentacoesRecentes.length === 0) {
-      movimentacoesRecentes.push({ time: '08:00', description: 'Nenhuma movimentação recente registrada.', icon: 'Circle', color: 'text-muted-foreground' });
+      movimentacoesRecentes.push({ data: '—', description: 'Nenhuma movimentação recente registrada.', icon: 'Circle', color: 'text-muted-foreground' });
     }
 
     // 4. Distribuição da Mão de Obra por Obra
@@ -786,7 +785,11 @@ export async function obterDashboardStats(req, res) {
       }
     });
 
-    const distribuicaoMaoObra = Object.entries(distribuicaoMap).map(([name, value]) => ({ name, value }));
+    // Top 8 obras por nº de pessoas (evita o gráfico amontoado/ilegível).
+    const distribuicaoMaoObra = Object.entries(distribuicaoMap)
+      .map(([name, value]) => ({ name, value }))
+      .sort((a, b) => b.value - a.value)
+      .slice(0, 8);
     if (distribuicaoMaoObra.length === 0) {
       distribuicaoMaoObra.push({ name: 'Sem Obras com Equipe', value: 0 });
     }

--- a/frontend/vite-project/src/layout/RHSidebar.jsx
+++ b/frontend/vite-project/src/layout/RHSidebar.jsx
@@ -2,10 +2,11 @@ import React, { useState } from 'react';
 import { NavLink, useLocation, useNavigate } from 'react-router';
 import {
   Users, Briefcase, UserPlus, Clock, BookOpen, Shield, Umbrella,
-  DollarSign, Layers, BarChart3, Home, ChevronDown, ChevronRight, Settings, Menu, X
+  DollarSign, Layers, BarChart3, Home, ChevronDown, ChevronRight, Settings, Menu, X, Sun, Moon
 } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useRHSidebar } from '../context/RHSidebarContext';
+import { useTheme } from '../context/ThemeContext';
 import toast from 'react-hot-toast';
 
 const iconMap = {
@@ -16,6 +17,7 @@ const iconMap = {
 export default function RHSidebar() {
   const { user, logout } = useAuth();
   const { collapsed, toggleCollapse } = useRHSidebar();
+  const { theme, toggleTheme } = useTheme();
   const location = useLocation();
   const navigate = useNavigate();
   const [expandedMenu, setExpandedMenu] = useState('pessoas');
@@ -239,6 +241,18 @@ export default function RHSidebar() {
 
       {/* Bottom Menu */}
       <div className={`space-y-2 ${collapsed ? 'px-2 py-4' : 'px-3 py-4'}`}>
+        <button
+          onClick={toggleTheme}
+          className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-accent transition-colors ${
+            collapsed ? 'justify-center' : ''
+          }`}
+          title={collapsed ? (theme === 'dark' ? 'Modo claro' : 'Modo escuro') : ''}
+        >
+          {theme === 'dark'
+            ? <Sun size={18} className="flex-shrink-0" />
+            : <Moon size={18} className="flex-shrink-0" />}
+          {!collapsed && (theme === 'dark' ? 'Modo claro' : 'Modo escuro')}
+        </button>
         <button
           onClick={() => toast('Favoritos — em breve')}
           className={`w-full flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium text-foreground hover:bg-accent transition-colors ${

--- a/frontend/vite-project/src/pages/RH/RHDashboard.jsx
+++ b/frontend/vite-project/src/pages/RH/RHDashboard.jsx
@@ -111,6 +111,15 @@ export default function RHDashboard() {
     { icon: BarChart2, label: 'Alocar em Obra', action: '/rh/equipes-obra' }
   ];
 
+  const kpis = [
+    { label: 'Colaboradores Ativos', value: stats.colaboradoresAtivos, color: 'text-foreground', to: '/rh/colaboradores' },
+    { label: 'Admissões em Andamento', value: stats.admissoesEmAndamento, color: 'text-amber-600', to: '/rh/contratacoes' },
+    { label: 'Férias Programadas', value: stats.feriasProgramadas, color: 'text-blue-600', to: '/rh/ferias' },
+    { label: 'Afastamentos', value: stats.afastamentos, color: 'text-orange-600', to: '/rh/afastamentos' },
+    { label: 'Exames Pendentes', value: stats.examesPendentes, color: 'text-red-600', to: '/rh/exames' },
+    { label: 'Custo de Mão de Obra', value: `R$ ${(stats.custoMaoObra / 1000000).toFixed(1)}M`, color: 'text-emerald-600', to: '/rh/folha-pagamento' },
+  ];
+
   return (
     <div className="min-h-screen bg-background" aria-busy={loading}>
       {/* Header */}
@@ -201,66 +210,17 @@ export default function RHDashboard() {
         <h2 className="text-2xl font-bold text-foreground mb-6">Indicadores Principais</h2>
         
         {/* Cards de KPIs */}
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-6 gap-4 mb-8">
-          <Link to="/rh/colaboradores" className="bg-card border border-border rounded-lg p-6 shadow-sm hover:shadow-lg transition-all cursor-pointer">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-muted-foreground text-sm">Colaboradores Ativos</p>
-                <p className="text-3xl font-bold text-foreground mt-2">{stats.colaboradoresAtivos}</p>
-              </div>
-              <Users size={40} className="text-primary/30" />
-            </div>
-          </Link>
-
-          <Link to="/rh/contratacoes" className="bg-card border border-border rounded-lg p-6 shadow-sm hover:shadow-lg transition-all cursor-pointer">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-muted-foreground text-sm">Admissões em Andamento</p>
-                <p className="text-3xl font-bold text-yellow-600 mt-2">{stats.admissoesEmAndamento}</p>
-              </div>
-              <UserCheck size={40} className="text-yellow-600/30" />
-            </div>
-          </Link>
-
-          <Link to="/rh/ferias" className="bg-card border border-border rounded-lg p-6 shadow-sm hover:shadow-lg transition-all cursor-pointer">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-muted-foreground text-sm">Férias Programadas</p>
-                <p className="text-3xl font-bold text-blue-600 mt-2">{stats.feriasProgramadas}</p>
-              </div>
-              <Clock size={40} className="text-blue-600/30" />
-            </div>
-          </Link>
-
-          <Link to="/rh/afastamentos" className="bg-card border border-border rounded-lg p-6 shadow-sm hover:shadow-lg transition-all cursor-pointer">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-muted-foreground text-sm">Afastamentos</p>
-                <p className="text-3xl font-bold text-orange-600 mt-2">{stats.afastamentos}</p>
-              </div>
-              <Heart size={40} className="text-orange-600/30" />
-            </div>
-          </Link>
-
-          <Link to="/rh/exames" className="bg-card border border-border rounded-lg p-6 shadow-sm hover:shadow-lg transition-all cursor-pointer">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-muted-foreground text-sm">Exames Pendentes</p>
-                <p className="text-3xl font-bold text-red-600 mt-2">{stats.examesPendentes}</p>
-              </div>
-              <AlertTriangle size={40} className="text-red-600/30" />
-            </div>
-          </Link>
-
-          <Link to="/rh/folha-pagamento" className="bg-card border border-border rounded-lg p-6 shadow-sm hover:shadow-lg transition-all cursor-pointer">
-            <div className="flex items-center justify-between">
-              <div>
-                <p className="text-muted-foreground text-sm">Custo de Mão de Obra</p>
-                <p className="text-3xl font-bold text-green-600 mt-2">R$ {(stats.custoMaoObra / 1000000).toFixed(1)}M</p>
-              </div>
-              <DollarSign size={40} className="text-green-600/30" />
-            </div>
-          </Link>
+        <div className="grid grid-cols-2 sm:grid-cols-3 xl:grid-cols-6 gap-4 mb-8">
+          {kpis.map((kpi) => (
+            <Link
+              key={kpi.label}
+              to={kpi.to}
+              className="bg-card border border-border rounded-xl p-5 shadow-sm hover:shadow-md hover:border-primary/30 transition-all flex flex-col gap-2 min-h-[112px]"
+            >
+              <p className="text-[11px] font-semibold uppercase tracking-wide text-muted-foreground leading-snug">{kpi.label}</p>
+              <p className={`text-3xl font-bold leading-none mt-auto ${kpi.color}`}>{kpi.value}</p>
+            </Link>
+          ))}
         </div>
 
         {/* Alertas Críticos e Movimentações Recentes */}
@@ -311,7 +271,7 @@ export default function RHDashboard() {
                         )}
                       </div>
                       <div className="ml-8">
-                        <p className="text-xs text-muted-foreground">{item.time}</p>
+                        <p className="text-xs text-muted-foreground">{item.data}</p>
                         <p className="text-sm text-foreground font-medium">{item.description}</p>
                       </div>
                     </div>
@@ -327,14 +287,22 @@ export default function RHDashboard() {
           {/* Distribuição da Mão de Obra */}
           <div>
             <h2 className="text-2xl font-bold text-foreground mb-4">Distribuição da Mão de Obra</h2>
-            <div className="bg-card border border-border rounded-lg p-6 h-[300px] shadow-sm">
+            <div className="bg-card border border-border rounded-lg p-6 h-[340px] shadow-sm">
               <ResponsiveContainer width="100%" height="100%">
-                <BarChart data={distribuicaoMaoObra} layout="vertical" margin={{ top: 20, right: 30, left: 120, bottom: 5 }}>
-                  <CartesianGrid strokeDasharray="3 3" horizontal={false} />
+                <BarChart data={distribuicaoMaoObra} layout="vertical" margin={{ top: 8, right: 24, left: 16, bottom: 8 }}>
+                  <CartesianGrid strokeDasharray="3 3" horizontal={false} stroke="#94a3b8" strokeOpacity={0.25} />
                   <XAxis type="number" hide />
-                  <YAxis type="category" dataKey="name" axisLine={false} tickLine={false} />
-                  <Tooltip />
-                  <Bar dataKey="value" fill="hsl(var(--primary))" />
+                  <YAxis
+                    type="category"
+                    dataKey="name"
+                    axisLine={false}
+                    tickLine={false}
+                    width={150}
+                    tick={{ fontSize: 12, fill: '#94a3b8' }}
+                    tickFormatter={(v) => (v.length > 18 ? v.slice(0, 17) + '…' : v)}
+                  />
+                  <Tooltip cursor={{ fill: 'rgba(148,163,184,0.1)' }} />
+                  <Bar dataKey="value" fill="#6366f1" radius={[0, 6, 6, 0]} barSize={18} />
                 </BarChart>
               </ResponsiveContainer>
             </div>


### PR DESCRIPTION
## Cards de KPI
- Removidos os ícones; cards padronizados (rótulo em cima, número grande embaixo, mesma altura).

## Movimentações Recentes
- Passa a mostrar a data de admissão real (antes era "08:00" fixo em tudo).

## Distribuição da Mão de Obra
- Top 8 obras (evita o amontoado), barras com cor legível e nomes sem sobreposição.

## Dark mode
- Botão de alternar tema (Sol/Lua) adicionado na sidebar do RH.

## Correção
- Alertas Críticos agora levam às telas novas (ex: "sem obra" → /rh/colaboradores), não mais ao dashboard antigo (/rh).

## Backend (rhController.js)
- Movimentações usam data_admissao; distribuição limitada ao top 8; links de alerta corrigidos.

## Testes
- ESLint limpo no front; `node --check` no back; `dashboard-stats` retornando 200 verificado.